### PR TITLE
Enable IReferenceable on all types.

### DIFF
--- a/ftw/news/profiles/default/types/ftw.news.News.xml
+++ b/ftw/news/profiles/default/types/ftw.news.News.xml
@@ -38,6 +38,7 @@
         <element value="plone.app.dexterity.behaviors.exclfromnav.IExcludeFromNavigation"/>
         <element value="Products.CMFPlone.interfaces.constrains.ISelectableConstrainTypes"/>
         <element value="plone.app.relationfield.behavior.IRelatedItems"/>
+        <element value="plone.app.referenceablebehavior.referenceable.IReferenceable"/>
     </property>
 
     <!-- View information -->

--- a/ftw/news/profiles/default/types/ftw.news.NewsFolder.xml
+++ b/ftw/news/profiles/default/types/ftw.news.NewsFolder.xml
@@ -29,6 +29,7 @@
         <element value="plone.app.dexterity.behaviors.metadata.IDublinCore"/>
         <element value="plone.app.content.interfaces.INameFromTitle" />
         <element value="plone.app.dexterity.behaviors.exclfromnav.IExcludeFromNavigation"/>
+        <element value="plone.app.referenceablebehavior.referenceable.IReferenceable"/>
     </property>
 
     <!-- View information -->

--- a/ftw/news/profiles/default/types/ftw.news.NewsListingBlock.xml
+++ b/ftw/news/profiles/default/types/ftw.news.NewsListingBlock.xml
@@ -26,6 +26,7 @@
     <property name="behaviors">
         <element value="plone.app.content.interfaces.INameFromTitle" />
         <element value="ftw.simplelayout.interfaces.ISimplelayoutBlock" />
+        <element value="plone.app.referenceablebehavior.referenceable.IReferenceable"/>
     </property>
 
    <!-- View information -->


### PR DESCRIPTION
Closes #3 
The IReferenceable behavior adds the objects to the reference catalog.
We need this in order to lookup objects by UUID.