### PR TITLE
Remove the news folder schema.

### DIFF
--- a/ftw/news/contents/news_folder.py
+++ b/ftw/news/contents/news_folder.py
@@ -1,19 +1,13 @@
-from ftw.news import _
 from ftw.news.interfaces import INewsFolder
 from plone.autoform.interfaces import IFormFieldProvider
 from plone.dexterity.content import Container
 from plone.directives import form
-from zope import schema
 from zope.interface import alsoProvides
 from zope.interface import implements
 
 
 class INewsFolderSchema(form.Schema):
-    show_title = schema.Bool(
-        title=_(u'news_folder_show_title_title_label', default=u'Show title'),
-        default=True,
-        required=False,
-    )
+    pass
 
 alsoProvides(INewsFolderSchema, IFormFieldProvider)
 

--- a/ftw/news/locales/de/LC_MESSAGES/ftw.news.po
+++ b/ftw/news/locales/de/LC_MESSAGES/ftw.news.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-07-22 10:06+0000\n"
+"POT-Creation-Date: 2015-07-31 06:59+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -78,11 +78,6 @@ msgstr "News-Einträge werden nach diesem Datum sortiert"
 #: ./ftw/news/contents/news.py:17
 msgid "news_date_label"
 msgstr "Datum des News-Eintrages"
-
-#. Default: "Show title"
-#: ./ftw/news/contents/news_folder.py:13
-msgid "news_folder_show_title_title_label"
-msgstr "Titel anzeigen"
 
 #. Default: "by ${author}"
 #: ./ftw/news/browser/templates/news_listing.pt:55
@@ -221,22 +216,22 @@ msgid "news_portlet_always_render_portlet_label"
 msgstr "Portlet immer anzeigen"
 
 #. Default: "Cancel"
-#: ./ftw/news/portlets/news_portlet.py:241
+#: ./ftw/news/portlets/news_portlet.py:244
 msgid "news_portlet_edit_form_cancel_label"
 msgstr "Abbrechen"
 
 #. Default: "This portlet displays news items"
-#: ./ftw/news/portlets/news_portlet.py:203
+#: ./ftw/news/portlets/news_portlet.py:206
 msgid "news_portlet_edit_form_description"
 msgstr "Dieses Portlet zeigt News an"
 
 #. Default: "Edit News Portlet"
-#: ./ftw/news/portlets/news_portlet.py:202
+#: ./ftw/news/portlets/news_portlet.py:205
 msgid "news_portlet_edit_form_label"
 msgstr "News-Portlet bearbeiten"
 
 #. Default: "Save"
-#: ./ftw/news/portlets/news_portlet.py:224
+#: ./ftw/news/portlets/news_portlet.py:227
 msgid "news_portlet_edit_form_save_label"
 msgstr "Speichern"
 

--- a/ftw/news/locales/ftw.news.pot
+++ b/ftw/news/locales/ftw.news.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-07-22 10:06+0000\n"
+"POT-Creation-Date: 2015-07-31 06:59+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -77,11 +77,6 @@ msgstr ""
 #. Default: "Date"
 #: ./ftw/news/contents/news.py:17
 msgid "news_date_label"
-msgstr ""
-
-#. Default: "Show title"
-#: ./ftw/news/contents/news_folder.py:13
-msgid "news_folder_show_title_title_label"
 msgstr ""
 
 #. Default: "by ${author}"
@@ -221,22 +216,22 @@ msgid "news_portlet_always_render_portlet_label"
 msgstr ""
 
 #. Default: "Cancel"
-#: ./ftw/news/portlets/news_portlet.py:241
+#: ./ftw/news/portlets/news_portlet.py:244
 msgid "news_portlet_edit_form_cancel_label"
 msgstr ""
 
 #. Default: "This portlet displays news items"
-#: ./ftw/news/portlets/news_portlet.py:203
+#: ./ftw/news/portlets/news_portlet.py:206
 msgid "news_portlet_edit_form_description"
 msgstr ""
 
 #. Default: "Edit News Portlet"
-#: ./ftw/news/portlets/news_portlet.py:202
+#: ./ftw/news/portlets/news_portlet.py:205
 msgid "news_portlet_edit_form_label"
 msgstr ""
 
 #. Default: "Save"
-#: ./ftw/news/portlets/news_portlet.py:224
+#: ./ftw/news/portlets/news_portlet.py:227
 msgid "news_portlet_edit_form_save_label"
 msgstr ""
 


### PR DESCRIPTION
Since it makes no sense to be able to say whether the title of the news folder should be shown or not, the schema has no remaining fields and is therefor removed.