### PR TITLE
Improve templates used for rendering the news items.

### DIFF
--- a/ftw/news/browser/templates/news_listing.pt
+++ b/ftw/news/browser/templates/news_listing.pt
@@ -63,13 +63,11 @@
                     </tal:author>
                 </div>
 
-                <p class="tileBody">
-                    <span class="description"
-                       tal:content="item/description">
-                    </span>
+                <p class="tileBody" tal:condition="item/description">
+                    <span class="description" tal:content="item/description" />
                 </p>
 
-                <p class="tileFooter">
+                <p class="tileFooter" tal:condition="item/url">
                     <a tal:attributes="href item/url"
                        i18n:translate="news_listing_read_more_label">Read More&hellip;</a>
                 </p>

--- a/ftw/news/browser/templates/news_listing_block.pt
+++ b/ftw/news/browser/templates/news_listing_block.pt
@@ -20,8 +20,7 @@
             <p tal:condition="not: news"
                i18n:translate="">No content available</p>
 
-            <div class="newsItem" tal:condition="news"
-                 tal:repeat="item news">
+            <div class="newsItem" tal:condition="news" tal:repeat="item news">
 
                 <div tal:condition="item/image_tag"
                      tal:content="structure item/image_tag"
@@ -35,18 +34,19 @@
                 <div class="documentByLine">
                     <span tal:condition="item/news_date"
                           tal:content="item/news_date"/>
-                    <span condition="item/author"
-                          i18n:translate="news_listing_author_label">
-                        by
-                        <span tal:content="item/author"
-                              i18n:name="author">Author</span>
-                    </span>
+                    <tal:author condition="item/author">
+                        <span i18n:translate="news_listing_author_label">
+                            by
+                            <span tal:content="item/author"
+                                  i18n:name="author">Author</span>
+                        </span>
+                    </tal:author>
                 </div>
-                <p class="newsbody">
-                    <span class="description" tal:content="item/description"
-                          tal:condition="item/description">Description</span>
+                <p class="newsbody" tal:condition="item/description">
+                    <span class="description"
+                          tal:content="item/description">Description</span>
                 </p>
-                <p class="newsFooter">
+                <p class="newsFooter" tal:condition="item/url">
                     <a tal:attributes="href item/url"
                        i18n:translate="">Read more</a>
                 </p>

--- a/ftw/news/tests/utils.py
+++ b/ftw/news/tests/utils.py
@@ -1,4 +1,5 @@
 from ftw.simplelayout.interfaces import IPageConfiguration
+from plone import api
 from plone.uuid.interfaces import IUUID
 import transaction
 
@@ -21,4 +22,10 @@ def create_page_state(obj, block):
     }
     page_config = IPageConfiguration(obj)
     page_config.store(page_state)
+    transaction.commit()
+
+
+def set_allow_anonymous_view_about(state):
+    site_props = api.portal.get_tool(name='portal_properties').site_properties
+    site_props.allowAnonymousViewAbout = state
     transaction.commit()


### PR DESCRIPTION
This fixes a bug regarding the rendering of the author and the rendering of empty HTML tags.

Closes 4teamwork/bern.web#358