### PR TITLE
Check for interface instead of portal type.

### DIFF
--- a/ftw/news/browser/news_listing.py
+++ b/ftw/news/browser/news_listing.py
@@ -1,10 +1,4 @@
 from Acquisition import aq_parent, aq_inner
-from ftw.news import _
-from ftw.news import utils
-from ftw.news.interfaces import INewsListingView
-from plone.portlets.interfaces import IPortletAssignmentMapping
-from plone.portlets.interfaces import IPortletManager
-from plone.portlets.interfaces import IPortletRenderer
 from Products.CMFCore.permissions import AccessInactivePortalContent
 from Products.CMFCore.utils import _checkPermission
 from Products.CMFCore.utils import getToolByName
@@ -12,12 +6,17 @@ from Products.CMFPlone.interfaces import IPloneSiteRoot
 from Products.CMFPlone.PloneBatch import Batch
 from Products.Five.browser import BrowserView
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
+from ftw.news import _
+from ftw.news import utils
+from ftw.news.interfaces import INewsListingView, INewsFolder
+from plone.portlets.interfaces import IPortletAssignmentMapping
+from plone.portlets.interfaces import IPortletManager
+from plone.portlets.interfaces import IPortletRenderer
 from zope.component import getMultiAdapter
 from zope.component import getUtility
 from zope.component import queryMultiAdapter
 from zope.interface import implements
 import DateTime
-import datetime
 
 
 class NewsListing(BrowserView):
@@ -82,7 +81,7 @@ class NewsListing(BrowserView):
     @property
     def title(self):
         title = self.context.Title()
-        if self.context.portal_type == 'ftw.news.NewsFolder':
+        if INewsFolder.providedBy(self.context):
             return title
         return self.context.Title() + ' - News'
 

--- a/ftw/news/portlets/news_portlet.py
+++ b/ftw/news/portlets/news_portlet.py
@@ -1,14 +1,15 @@
 from Acquisition import aq_parent, aq_inner
 from DateTime import DateTime
+from Products.CMFCore.utils import getToolByName
+from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from ftw.news import _
 from ftw.news import utils
 from ftw.news.contents.common import INewsListingBaseSchema
+from ftw.news.interfaces import INewsFolder
 from plone.app.portlets.interfaces import IPortletPermissionChecker
 from plone.app.portlets.portlets import base
 from plone.directives.form.form import SchemaAddForm, SchemaEditForm
 from plone.portlets.interfaces import IPortletDataProvider
-from Products.CMFCore.utils import getToolByName
-from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from z3c.form import button
 from z3c.form import form as z3cform
 from zope import schema
@@ -112,7 +113,7 @@ class Renderer(base.Renderer):
         if getattr(self.data, 'always_render_portlet', False):
             return True
 
-        if self.data.portal_type == 'ftw.news.NewsFolder':
+        if INewsFolder.providedBy(self.data):
             return False
 
         if self.data.show_more_news_link:


### PR DESCRIPTION
This is needed to work for other types based on the news type.