### PR TITLE
Render the news date (below title) only for news types.

### DIFF
--- a/ftw/news/viewlets/news_date.py
+++ b/ftw/news/viewlets/news_date.py
@@ -8,6 +8,8 @@ class NewsDateViewlet(ViewletBase):
     template = ViewPageTemplateFile('news_date.pt')
 
     def render(self):
+        if not self.context.portal_type == 'ftw.news.News':
+            return ''
         return self.template()
 
     def update(self):


### PR DESCRIPTION
Types based on the news might render the date at a different location.