### PR TITLE
Include the brain itself when returning the data of the news item.

### DIFF
--- a/ftw/news/browser/news_listing_block.py
+++ b/ftw/news/browser/news_listing_block.py
@@ -85,6 +85,7 @@ class NewsListingBlockView(BaseBlock):
             'author': author,
             'news_date': self.format_date(brain),
             'image_tag': image_tag,
+            'brain': brain,
         }
         return item
 


### PR DESCRIPTION
This is useful for other projects building on top of "ftw.news" which need to display more information of the item in the template.