### PR TITLE
Improve performance for listing

### DIFF
--- a/ftw/news/browser/news_listing.py
+++ b/ftw/news/browser/news_listing.py
@@ -59,8 +59,7 @@ class NewsListing(BrowserView):
     def get_items(self):
         catalog = getToolByName(self.context, 'portal_catalog')
         show_inactive = _checkPermission(AccessInactivePortalContent, self.context)
-        brains = catalog(self.get_query(), show_inactive=show_inactive)
-        return [self.get_item_dict(brain) for brain in brains]
+        return catalog(self.get_query(), show_inactive=show_inactive)
 
     def get_item_dict(self, brain):
         obj = brain.getObject()
@@ -170,8 +169,14 @@ class NewsListingPortlet(NewsListing):
 
         return []
 
+    def get_item_dict(self, brain):
+        """Overrides the parents item_dict becuase
+        we have already a dict instead a brain from the news_portlet Renderer
+        """
+        return brain
+
     def title(self):
         portlet = self.get_portlet()
         if portlet:
             return portlet.data.news_listing_config_title
-        return super(NewsListingPortlet, self).title()
+        return super(NewsListingPortlet, self).title

--- a/ftw/news/browser/templates/news_listing.pt
+++ b/ftw/news/browser/templates/news_listing.pt
@@ -31,7 +31,9 @@
             <p tal:condition="not:batch"
                i18n:translate="news_listing_no_content_text">No content available</p>
 
-            <div tal:repeat="item batch" class="tileItem">
+            <tal:batch repeat="lazy_item batch">
+            <div class="tileItem"
+                tal:define="item python:view.get_item_dict(lazy_item)">
 
                 <div tal:condition="item/image_tag"
                      tal:content="structure item/image_tag"
@@ -66,6 +68,7 @@
 
                 <div class="visualClear"><!-- --></div>
             </div>
+            </tal:batch>
             <div metal:use-macro="context/batch_macros/macros/navigation" />
         </div>
 

--- a/ftw/news/browser/templates/news_listing_rss.pt
+++ b/ftw/news/browser/templates/news_listing_rss.pt
@@ -17,22 +17,25 @@
             <image tal:attributes="rdf:resource string:${context/portal_url}/logo.png" />
             <items>
                 <rdf:Seq>
-                    <tal:block repeat="item items">
+                    <tal:batch repeat="lazy_item items">
+                    <tal:block define="item python:view.get_item_dict(lazy_item)">
                         <rdf:li rdf:resource=""
                                 tal:attributes="rdf:resource item/url" />
                     </tal:block>
+                    </tal:batch>
                 </rdf:Seq>
             </items>
         </channel>
-
-        <tal:block repeat="item items">
+        <tal:batch repeat="lazy_item items">
+            <tal:block define="item python:view.get_item_dict(lazy_item)">
             <item rdf:about="" tal:attributes="rdf:about item/url">
                 <title tal:content="item/title" />
                 <span tal:replace="structure item/link_tag"></span>
                 <description tal:content="item/description" />
                 <pubDate tal:content="item/news_date"/>
             </item>
-        </tal:block>
+            </tal:block>
+        </tal:batch>
 
     </tal:block>
 


### PR DESCRIPTION
@maethu @mbaechtold 

Improve performance for listings. The Batchitems haven't been lazy...

Tested with 1000 entries:

Before:
======

![bildschirmfoto 2015-09-04 um 15 49 16](https://cloud.githubusercontent.com/assets/557005/9686357/ece8ebf4-5323-11e5-978a-8fc97b4be83c.png)

After:
=====

![bildschirmfoto 2015-09-04 um 15 48 32](https://cloud.githubusercontent.com/assets/557005/9686324/bbb2fbe2-5323-11e5-8537-e6bab2bfc6c7.png)
