### PR TITLE
Remove unused method

### DIFF
--- a/ftw/news/browser/news_listing.py
+++ b/ftw/news/browser/news_listing.py
@@ -134,6 +134,7 @@ class NewsListingPortlet(NewsListing):
                     (self.context, self.request, self,
                      manager, assignments[name]),
                     IPortletRenderer)
+
         return
 
     def get_manager_and_assignments(self, manager_name):
@@ -165,15 +166,9 @@ class NewsListingPortlet(NewsListing):
     def get_items(self):
         portlet = self.get_portlet()
         if portlet:
-            return portlet.get_items(all_news=True)
+            return portlet.get_news(all_news=True)
 
         return []
-
-    def get_item_dict(self, brain):
-        """Overrides the parents item_dict becuase
-        we have already a dict instead a brain from the news_portlet Renderer
-        """
-        return brain
 
     def title(self):
         portlet = self.get_portlet()


### PR DESCRIPTION
@maethu 

Refactored the get_item_dict.

The get_items method will be used in portlets too. So I can't remove it.

The get_news method returns all newsbrains. So the get_item_dict method from the news listing view can be dropped.