### PR TITLE
Use freeze from ftw.testing in our tests.

### DIFF
--- a/ftw/news/contents/news.py
+++ b/ftw/news/contents/news.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+import datetime
 from ftw.datepicker.widget import DatePickerFieldWidget
 from ftw.news import _
 from ftw.news.interfaces import INews
@@ -9,7 +9,7 @@ from zope.interface import implements
 
 
 def default_news_date():
-    return datetime.now()
+    return datetime.datetime.now()
 
 
 class INewsSchema(form.Schema):

--- a/ftw/news/tests/test_content_types.py
+++ b/ftw/news/tests/test_content_types.py
@@ -1,10 +1,11 @@
-from datetime import datetime
+import datetime
 from ftw.builder import Builder
 from ftw.builder import create
 from ftw.news.testing import FTW_NEWS_FUNCTIONAL_TESTING
 from ftw.news.tests import FunctionalTestCase
 from ftw.testbrowser import browsing
 from ftw.testbrowser.pages import factoriesmenu
+from ftw.testing import freeze
 
 
 class TestContentTypes(FunctionalTestCase):
@@ -42,14 +43,13 @@ class TestContentTypes(FunctionalTestCase):
     def test_default_news_date(self, browser):
         news_folder = create(Builder('news folder'))
 
-        now = datetime.now()
-        news = create(Builder('news')
-                      .titled(u'News Entry')
-                      .within(news_folder))
+        with freeze(datetime.datetime(2001, 5, 7, 11, 13, 17)):
+            news = create(Builder('news')
+                          .titled(u'News Entry')
+                          .within(news_folder))
 
         browser.login().open(news)
-        self.assertIn(
-            now.strftime('%b %d, %Y %I:'),
+        self.assertEqual(
+            'May 07, 2001 11:13 AM',
             browser.css('.news-date').first.text
         )
-

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ maintainer = 'Mathias Leimgruber'
 tests_require = [
     'ftw.builder',
     'ftw.testbrowser',
-    'ftw.testing',
+    'ftw.testing>=1.11.0',
     'plone.app.testing',
     'plone.testing',
 ]


### PR DESCRIPTION
This pull requests makes testing of the default news date more robust.