### PR TITLE
Use the news start date index to filter news items.

### DIFF
--- a/ftw/news/browser/news_listing_block.py
+++ b/ftw/news/browser/news_listing_block.py
@@ -73,7 +73,7 @@ class NewsListingBlockView(BaseBlock):
 
         if self.context.maximum_age > 0:
             date = DateTime() - self.context.maximum_age
-            query['effective'] = {'query': date, 'range': 'min'}
+            query['start'] = {'query': date, 'range': 'min'}
 
         query['sort_on'] = 'start'
         query['sort_order'] = 'descending'

--- a/ftw/news/portlets/news_portlet.py
+++ b/ftw/news/portlets/news_portlet.py
@@ -145,7 +145,7 @@ class Renderer(base.Renderer):
 
         if self.data.maximum_age > 0 and not all_news:
             date = DateTime() - self.data.maximum_age
-            query['effective'] = {'query': date, 'range': 'min'}
+            query['start'] = {'query': date, 'range': 'min'}
 
         query['sort_on'] = 'start'
         query['sort_order'] = 'descending'

--- a/ftw/news/tests/test_news_detail.py
+++ b/ftw/news/tests/test_news_detail.py
@@ -19,10 +19,10 @@ class TestNewsDetail(FunctionalTestCase):
         news_folder = create(Builder('news folder').titled(u'A News Folder'))
 
         news_date = datetime(2000, 12, 31, 13, 0, 0)
-        news = create(Builder('news').titled(u'News Entry 1')
+        news = create(Builder('news')
+                      .titled(u'News Entry 1')
                       .within(news_folder)
-                      .having(effective=news_date, news_date=news_date)
-                      )
+                      .having(news_date=news_date))
 
         browser.login().visit(news)
         self.assertEqual(

--- a/ftw/news/tests/test_news_listing.py
+++ b/ftw/news/tests/test_news_listing.py
@@ -20,17 +20,11 @@ class TestNewsListing(FunctionalTestCase):
         self.news_folder = create(Builder('news folder')
                                   .titled(u'A News Folder'))
 
-        yesterday = datetime.today() - timedelta(days=1)
-        self.news1 = create(Builder('news').titled(u'News Entry 1')
+        yesterday = datetime.now() - timedelta(days=1)
+        self.news1 = create(Builder('news')
+                            .titled(u'News Entry 1')
                             .within(self.news_folder)
-                            .having(effective=yesterday, news_date=yesterday)
-                            )
-
-        tomorrow = datetime.today() + timedelta(days=1)
-        self.news2 = create(Builder('news').titled(u'News Entry 2')
-                            .within(self.news_folder)
-                            .having(effective=tomorrow, news_date=tomorrow)
-                            )
+                            .having(news_date=yesterday))
 
         set_allow_anonymous_view_about(False)
 
@@ -86,18 +80,6 @@ class TestNewsListing(FunctionalTestCase):
             browser.css('.newsListing .documentAuthor').first.text,
             'Anonymous user should see author if '
             'allowAnonymousViewAbout is True.')
-
-    @browsing
-    def test_inactive_news_is_visible_for_contributor(self, browser):
-        browser.login(self.contributor)
-        browser.visit(self.news_folder, view='@@news_listing')
-        self.assertEqual(2, len(browser.css('div.tileItem')))
-
-    @browsing
-    def test_inactive_news_is_not_visible_for_regular_users(self, browser):
-        browser.login(self.member)
-        browser.visit(self.news_folder, view='@@news_listing')
-        self.assertEqual(1, len(browser.css('div.tileItem')))
 
     @browsing
     def test_news_listing_inside_contentpage(self, browser):

--- a/ftw/news/tests/test_news_portlets.py
+++ b/ftw/news/tests/test_news_portlets.py
@@ -309,17 +309,23 @@ class TestNewsPortlets(FunctionalTestCase):
     def test_portlet_filters_old_news(self, browser):
         news_folder = create(Builder('news folder').titled(u'News Folder'))
 
-        old = datetime.today()-timedelta(days=10)
-        older = datetime.today()-timedelta(days=50)
+        old = datetime.now() - timedelta(days=10)
+        older = datetime.now() - timedelta(days=50)
 
-        create(Builder('news').titled(u'Hello World 1').within(news_folder)
-               .having(effective=old, news_date=old))
-        create(Builder('news').titled(u'Hello World 2').within(news_folder)
-               .having(effective=older, news_date=older))
+        create(Builder('news')
+               .titled(u'Hello World 1')
+               .within(news_folder)
+               .having(news_date=old))
+
+        create(Builder('news')
+               .titled(u'Hello World 2')
+               .within(news_folder)
+               .having(news_date=older))
 
         portlet_config = {
             'Title': 'A News Portlet',
             'Maximum age (days)': u'20',
+            'Limit to current context': False,
         }
         self._add_portlet(browser, **portlet_config)
         self.assertEquals(1, len(browser.css('li.portletItem')))


### PR DESCRIPTION
Until now the news items shown in the news portlet and the news listing view were filtered by the effective date, but the dublin core behavior has been removed in a previous commit (thus removing the publication behavior too).

A recent change in "ftw.builder" now made some shortcomings in the tests visible, which were due to the removal of the behavior mentioned above.

This commit removes the filtering by effective date and adds filtering by the news start date. Policy packages still can add the publication behavior for the news type.