### PR TITLE
The amount of items displayed are limited to 200 for rss listing

### DIFF
--- a/ftw/news/browser/news_listing.py
+++ b/ftw/news/browser/news_listing.py
@@ -97,6 +97,11 @@ class NewsListing(BrowserView):
 
 class NewsListingRss(NewsListing):
 
+    max_items = 200
+
+    def get_items(self):
+        return super(NewsListingRss, self).get_items()[:self.max_items]
+
     def get_channel_link_tag(self):
         """
         Returns a string containing a link tag.


### PR DESCRIPTION
Hardlimit the amount of displayed items in the rss listing to 200.
