### PR TITLE
Eliminate declaration warning for nonexistent methods.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,8 @@ Changelog
 1.0.1 (unreleased)
 ------------------
 
+- Eliminate declaration warning for nonexistent methods. [jone]
+
 - Apply styling based on new ftw.theming variables set.
   - Remove `read more` link becuase the link of the heading has the same target
     so the `read more` link is obsolete.

--- a/ftw/news/browser/configure.zcml
+++ b/ftw/news/browser/configure.zcml
@@ -22,7 +22,6 @@
         class=".news_listing.NewsListingRss"
         template="./templates/news_listing_rss.pt"
         permission="zope2.View"
-        allowed_attributes="news_result get_news"
         />
 
     <browser:page


### PR DESCRIPTION
The `news_listing_rss` view allows to traverse to `news_result` and `get_news`, but those methods do not exist.
This removes the declaration, eliminating a warning.
```
2016-02-02 17:49:09 WARNING Init Class Products.Five.metaclass.SimpleViewClass from /..../ftw.news/ftw/news/browser/templates/news_listing_rss.pt has a security declaration for nonexistent method 'news_result'
2016-02-02 17:49:09 WARNING Init Class Products.Five.metaclass.SimpleViewClass from /..../ftw.news/ftw/news/browser/templates/news_listing_rss.pt has a security declaration for nonexistent method 'get_news'
```