### PR TITLE
Clock icon of news headline is not aligend with the content.

### DIFF
--- a/ftw/news/browser/resources/news.scss
+++ b/ftw/news/browser/resources/news.scss
@@ -3,8 +3,6 @@
 @include portal-type-font-awesome-icon(ftw-news-newslistingblock, newspaper-o);
 
 .portletItemDate {
-  @extend .fa-icon;
-  @extend .fa-clock-o;
   color: $color-text-light;
   font-size: $font-size-small;
   margin-bottom: $margin-heading-vertical;
@@ -59,8 +57,6 @@
   }
 
   .documentByLine {
-    @extend .fa-icon;
-    @extend .fa-clock-o;
     font-size: $font-size-small;
     margin-bottom: 0;
     margin-bottom: $margin-heading-vertical;


### PR DESCRIPTION
Fixes https://github.com/OneGov/plonetheme.onegovbear/issues/112

![bildschirmfoto 2016-02-03 um 11 45 35](https://cloud.githubusercontent.com/assets/1637820/12780112/40699016-ca6c-11e5-9be7-e16a1062e2d1.png)
![bildschirmfoto 2016-02-03 um 11 48 16](https://cloud.githubusercontent.com/assets/1637820/12780113/406a07c6-ca6c-11e5-9e09-2983ee397055.png)
