### PR TITLE
Default state of archive portlet should not be expanded.

### DIFF
--- a/ftw/news/browser/resources/archive.scss
+++ b/ftw/news/browser/resources/archive.scss
@@ -6,21 +6,24 @@
   .year {
     .yearnumber {
       @extend .fa-icon;
-      @extend .fa-chevron-down;
+      @extend .fa-chevron-right;
     }
 
-    &.collapsed {
+    &.expanded {
       .yearnumber {
         @extend .fa-icon;
-        @extend .fa-chevron-right;
+        @extend .fa-chevron-down;
       }
       .months {
-        display: none;
+        display: block;
       }
     }
   }
 
-  .months a {
-    padding-left: $padding-horizontal * 2;
+  .months {
+    display: none;
+    a {
+      padding-left: $padding-horizontal * 2;
+    }
   }
 }

--- a/ftw/news/browser/resources/collapse_archive.js
+++ b/ftw/news/browser/resources/collapse_archive.js
@@ -1,7 +1,7 @@
 jQuery(function($){
     $(document).ready(function(){
         $('.portletArchiveListing .year span.yearnumber').click(function() {
-            $(this).parent().toggleClass('collapsed');
+            $(this).parent().toggleClass('expanded');
         });
     });
 });


### PR DESCRIPTION
For large archives the archive portlet should be collapsed by default.