### PR TITLE
get_creator should no fail if the user no longer exists.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 1.0.1 (unreleased)
 ------------------
 
+- get_creator should no fail if the user no longer exists.
+  [mathias.leimgruber]
+
 - Eliminate declaration warning for nonexistent methods.
   [jone]
 

--- a/ftw/news/tests/test_news_listing.py
+++ b/ftw/news/tests/test_news_listing.py
@@ -5,6 +5,7 @@ from ftw.news.testing import FTW_NEWS_FUNCTIONAL_TESTING
 from ftw.news.tests import FunctionalTestCase
 from ftw.news.tests import utils
 from ftw.news.tests.utils import set_allow_anonymous_view_about
+from ftw.news.utils import get_creator
 from ftw.testbrowser import browsing
 from ftw.testbrowser.pages import plone
 
@@ -136,3 +137,13 @@ class TestNewsListing(FunctionalTestCase):
             'Textblock with image',
             browser.css('.newsListing .tileItem img').first.attrib['title']
         )
+
+    def test_get_creator_method_does_not_fail_if_user_is_inexistent(self):
+        userid = 'inexisting'
+
+        news = create(Builder('news')
+                      .titled(u'News Entry 1')
+                      .within(self.news_folder)
+                      .having(news_date=datetime.now()))
+        news.Creator = userid
+        self.assertEquals(userid, get_creator(news))

--- a/ftw/news/utils.py
+++ b/ftw/news/utils.py
@@ -12,6 +12,8 @@ def get_creator(item):
     creator = getattr(item, 'Creator', '')
     username = creator() if callable(creator) else creator
     user = api.user.get(username=username)
+    if user is None:
+        return creator
     fullname = user.getProperty('fullname')
     return fullname or user.id
 


### PR DESCRIPTION
This may happend if a user is deleted, or even more often if an external source users is in use.
Ex. LDAP.