### PR TITLE
Define styling for news.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 1.0.1 (unreleased)
 ------------------
 
+- Rework styling based on ftw.theming
+  [Kevin Bieri]
+
 - get_creator should no fail if the user no longer exists.
   [mathias.leimgruber]
 

--- a/ftw/news/browser/resources/news.scss
+++ b/ftw/news/browser/resources/news.scss
@@ -2,69 +2,89 @@
 @include portal-type-font-awesome-icon(ftw-news-newsfolder, newspaper-o);
 @include portal-type-font-awesome-icon(ftw-news-newslistingblock, newspaper-o);
 
-.portletItemDate {
-  color: $color-text-light;
-  font-size: $font-size-small;
-  margin-bottom: $margin-heading-vertical;
-}
+$leadimage-width: $scale-preview-width;
 
-.portletItemTitle {
-  font-size: $font-size-h3;
-}
-
-.newsTemplate {
-  ul {
-    @include list();
-    > li > a {
-      padding: 0;
-    }
-  }
-  .image {
-    margin-bottom: $margin-heading-vertical;
-  }
-}
-
-.newsMoreLink {
-  @extend .fa-icon;
-  @extend .fa-chevron-right;
-  margin-bottom: $margin-paragraph-vertical;
-}
-
-.RssLink {
-  @extend .fa-icon;
-  @extend .fa-chevron-right;
-}
-
-.newsListing {
+.news-row {
   @include list();
-  .image {
-    @include screen-small() {
-      float: left;
-      margin-right: $margin-horizontal * 2;
-      margin-bottom: 0;
-      img {
-        max-width: 400px;
+
+  .news-item {
+    @include no-link();
+    @include clearfix();
+    padding: 0;
+    margin-bottom: $margin-vertical * 2;
+
+    &:hover {
+      background-color: $color-gray-light;
+    }
+
+    .image {
+      @include screen-small() {
+        float: left;
+        > img {
+          max-width: $leadimage-width;
+        }
+      }
+      > img {
+        vertical-align: middle;
       }
     }
-    margin-bottom: $margin-paragraph-vertical;
-    img {
-      vertical-align: middle;
+
+    .body {
+      padding: $padding-vertical $padding-horizontal;
+      @include screen-small() {
+        padding-left: em($leadimage-width) + $padding-horizontal;
+      }
+
+      .news-more {
+        display: inline;
+        &:before {
+          min-width: 0;
+        }
+      }
+    }
+
+    .byline {
+      display: block;
+      font-size: $font-size-small;
+      color: $color-text-light;
+    }
+
+    .title {
+      font-size: $font-size-h3;
+      display: block;
     }
   }
+}
 
-  .tileHeadline {
-    font-size: $font-size-h3;
-  }
+.news-more {
+  @extend .fa-icon;
+  @extend .fa-caret-right;
+  display: block;
+}
 
-  .documentByLine {
-    font-size: $font-size-small;
-    margin-bottom: 0;
-    margin-bottom: $margin-heading-vertical;
-  }
+.news-rss {
+  @extend .fa-icon;
+  @extend .fa-rss;
+  display: block;
+}
 
-  .tileItem {
-    margin-bottom: $margin-vertical * 2;
-    padding-bottom: $padding-vertical * 2;
-    border-bottom: 1px solid $color-gray-dark;
+.news-date {
+  font-size: $font-size-small;
+  color: $color-text-light;
+}
+
+.news-portlet {
+  .news-item {
+    .image {
+      float: none;
+      > img {
+        max-width: 100%;
+      }
+    }
+    .body {
+      padding: 0;
+      padding-top: $padding-vertical;
+    }
   }
 }
+

--- a/ftw/news/browser/templates/news_listing.pt
+++ b/ftw/news/browser/templates/news_listing.pt
@@ -28,39 +28,31 @@
            i18n:translate="news_listing_no_content_text">No content available</p>
 
 
-        <ul class="newsListing">
-
+        <ul class="news-listing news-row">
             <tal:batch repeat="lazy_item batch">
-                <li class="tileItem"
-                    tal:define="item python:view.get_item_dict(lazy_item)">
+                <li tal:define="item python:view.get_item_dict(lazy_item)">
+                    <a class="news-item" tal:attributes="href item/url">
 
-                    <div class="tileHeadline">
-                        <a class="summary url"
-                           tal:attributes="href item/url"
-                           tal:content="item/title"></a>
-                    </div>
+                      <div tal:condition="item/image_tag"
+                           tal:content="structure item/image_tag"
+                           class="image">
+                      </div>
 
-                    <div class="documentByLine">
-                        <span class="dtstart" tal:content="item/news_date" />
-                        <tal:author condition="item/author">
-                            <span class="documentAuthor"
-                                  i18n:translate="news_listing_author_label">
-                                by
-                                <span tal:content="item/author" i18n:name="author" />
-                            </span>
-                        </tal:author>
-                    </div>
-
-                    <div tal:condition="item/image_tag"
-                         tal:content="structure item/image_tag"
-                         class="image">
-                    </div>
-
-                    <p class="tileBody" tal:condition="item/description">
-                        <span class="description" tal:content="item/description" />
-                    </p>
-
-                    <div class="visualClear"><!-- --></div>
+                      <div class="body">
+                          <span class="byline">
+                              <span class="dtstart" tal:content="item/news_date" />
+                              <tal:author condition="item/author">
+                                  <span class="author"
+                                        i18n:translate="news_listing_author_label">
+                                      by
+                                      <span tal:content="item/author" i18n:name="author" />
+                                  </span>
+                              </tal:author>
+                          </span>
+                          <h3 class="title" tal:content="item/title" />
+                          <span class="description" tal:content="item/description" tal:condition="item/description"/>
+                      </div>
+                    </a>
                 </li>
             </tal:batch>
         </ul>

--- a/ftw/news/browser/templates/news_listing_block.pt
+++ b/ftw/news/browser/templates/news_listing_block.pt
@@ -8,26 +8,22 @@
         tal:condition="block_info/show_title">
     </h2>
 
-    <tal:rss-url tal:define="rss_url block_info/rss_link_url">
-        <div tal:condition="rss_url" class="documentByLine">
-            <a tal:attributes="href rss_url" i18n:translate="">Subscribe to the RSS feed</a>
-        </div>
-    </tal:rss-url>
-
     <tal:news tal:define="news view/get_news;">
 
         <p tal:condition="not: news"
            i18n:translate="">No content available</p>
 
-        <ul class="newsListing">
-
-            <tal:loop repeat="item news">
-                <li class="tileItem">
-                    <div class="newsHeadline">
-                        <a tal:attributes="href item/url"
-                           tal:content="item/title">Link</a>
-                    </div>
-                    <div class="documentByLine">
+        <ul class="news-row">
+            <li class="news-item" tal:repeat="item news">
+                <div tal:condition="item/image_tag"
+                     tal:content="structure item/image_tag"
+                     class="image">
+                </div>
+                <div class="body">
+                    <a class="title" tal:attributes="href item/url">
+                        <h3 class="title" tal:content="item/title" />
+                    </a>
+                    <span class="byline">
                         <span tal:condition="item/news_date"
                               tal:content="item/news_date"/>
                         <tal:author condition="item/author">
@@ -37,35 +33,31 @@
                                       i18n:name="author">Author</span>
                             </span>
                         </tal:author>
-                    </div>
-
-                    <div tal:condition="item/image_tag"
-                         tal:content="structure item/image_tag"
-                         class="image">
-                    </div>
-
-                    <p class="newsbody" tal:condition="item/description">
-                        <span class="description"
-                              tal:content="item/description">Description</span>
-                    </p>
-                    <p class="newsFooter" tal:condition="item/url">
-                        <a tal:attributes="href item/url"
-                           i18n:translate="">Read more</a>
-                    </p>
-                    <div class="visualClear"><!-- --></div>
-            </tal:loop>
+                    </span>
+                    <span class="description" tal:content="item/description">Description</span>
+                    <a class="news-more"
+                       tal:attributes="href item/url"
+                       tal:condition="item/url"
+                       i18n:translate="">Read more</a>
+                </div>
+            </li>
 
         </ul>
 
-        <p tal:define="more_news_link_url block_info/more_news_link_url;
-                       more_news_link_label block_info/more_news_link_label"
-           tal:condition="more_news_link_url">
-            <a class="newsMoreLink"
+        <tal:footer tal:define="more_news_link_url block_info/more_news_link_url;
+                                more_news_link_label block_info/more_news_link_label;
+                                rss_url block_info/rss_link_url">
+            <a class="news-more"
+               tal:condition="more_news_link_url"
                title="More News"
                i18n:attributes="title more_news_link_label"
                tal:attributes="href more_news_link_url"
                tal:content="more_news_link_label"/>
-        </p>
+            <a class="news-rss"
+               tal:condition="rss_url"
+               tal:attributes="href rss_url"
+               i18n:translate="">Subscribe to the RSS feed</a>
+        </tal:footer>
 
     </tal:news>
 

--- a/ftw/news/portlets/templates/news_portlet.pt
+++ b/ftw/news/portlets/templates/news_portlet.pt
@@ -3,72 +3,54 @@
       tal:omit-tag="python: 1"
       i18n:domain="ftw.news">
 
-    <dl class="portlet newsTemplate"
+    <section class="news-portlet"
         tal:define="items view/get_items;">
 
-        <dt class="portletHeader">
-            <tal:title replace="view/data/news_listing_config_title" />
-        </dt>
+        <header>
+            <h3 tal:content="view/data/news_listing_config_title"></h3>
+        </header>
+        <ul class="news-row">
+            <li class="portletItem noRecentNews"
+                tal:condition="not: items"
+                i18n:translate="no_recent_news_label">No recent news available.</li>
 
-        <dd>
-            <ul>
-                <li class="portletItem noRecentNews"
-                    tal:condition="not: items"
-                    i18n:translate="no_recent_news_label">No recent news available.</li>
-
-                <tal:loop tal:repeat="item items">
-                    <li class="portletItem"
-                        tal:define="oddrow repeat/item/odd;
-                                    lastrow repeat/item/end"
-                        tal:attributes="class python:'%s%s' % (
-                                        lastrow and 'lastItem ' or '',
-                                        oddrow and 'portletItem even' or 'portletItem odd')">
-
-                        <div class="newsText">
-                            <a class="portletItemTitle"
-                                 tal:content="item/title"
-                                 tal:attributes="href item/url"/>
-
-                            <div class="portletItemDate"
-                                 tal:content="item/news_date" />
-
-                            <div tal:condition="item/image_tag"
-                                 tal:content="structure item/image_tag"
-                                 class="image">
-                            </div>
-
-                            <div class="portletItemDescription"
-                                 tal:condition="item/description">
-                                <div tal:content="item/description" />
-                            </div>
+            <tal:loop tal:repeat="item items">
+                <li>
+                    <a class="news-item" tal:attributes="href item/url">
+                        <div tal:condition="item/image_tag"
+                             tal:content="structure item/image_tag"
+                             class="image">
                         </div>
+                        <div class="body">
+                          <div class="title"
+                               tal:content="item/title" />
+                          <div class="byline"
+                               tal:content="item/news_date" />
+                          <div class="description"
+                               tal:condition="item/description"
+                               tal:content="item/description" />
+                        </div>
+                    </a>
+                </li>
+            </tal:loop>
 
-                        <div class="visualClear"><!-- --></div>
-                    </li>
-                </tal:loop>
-
-                <tal:portlet_footer
-                    tal:define="more_news_url view/more_news_url;
+        </ul>
+        <tal:footer tal:define="more_news_url view/more_news_url;
                                 show_rss_link view/show_rss_link">
-                    <li class="portletFooter"
-                        tal:condition="python: more_news_url or show_rss_link">
-
-                        <a class="newsMoreLink"
-                           title="More News"
-                           tal:condition="more_news_url"
-                           i18n:attributes="title more_news_link_label"
-                           tal:attributes="href more_news_url"
-                           i18n:translate="more_news_link_label">More News</a>
-
-                        <a class="RssLink"
-                           title="Subscribe to the RSS feed"
-                           tal:condition="show_rss_link"
-                           i18n:attributes="title rss_link_title"
-                           tal:attributes="href string:${context/@@plone_context_state/canonical_object_url}/news_listing_rss"
-                           i18n:translate="rss_link_title">Subscribe to the RSS feed</a>
-                    </li>
-                </tal:portlet_footer>
-            </ul>
-        </dd>
-    </dl>
+            <footer tal:condition="python: more_news_url or show_rss_link">
+                <a class="news-more"
+                   title="More News"
+                   tal:condition="more_news_url"
+                   i18n:attributes="title more_news_link_label"
+                   tal:attributes="href more_news_url"
+                   i18n:translate="more_news_link_label">More News</a>
+                <a class="news-rss"
+                   title="Subscribe to the RSS feed"
+                   tal:condition="show_rss_link"
+                   i18n:attributes="title rss_link_title"
+                   tal:attributes="href string:${context/@@plone_context_state/canonical_object_url}/news_listing_rss"
+                   i18n:translate="rss_link_title">Subscribe to the RSS feed</a>
+            </footer>
+        </tal:footer>
+    </section>
 </html>

--- a/ftw/news/tests/test_content_types.py
+++ b/ftw/news/tests/test_content_types.py
@@ -50,6 +50,6 @@ class TestContentTypes(FunctionalTestCase):
         browser.login().open(news)
         self.assertIn(
             now.strftime('%b %d, %Y %I:'),
-            browser.css('.newsDate').first.text
+            browser.css('.news-date').first.text
         )
 

--- a/ftw/news/tests/test_news_archive_portlets.py
+++ b/ftw/news/tests/test_news_archive_portlets.py
@@ -113,7 +113,7 @@ class TestNewsArchivePortlets(FunctionalTestCase):
         self._add_portlet(browser, news_folder)
 
         browser.find('January (2)').click()
-        self.assertEqual(2, len(browser.css('li.tileItem')))
+        self.assertEqual(2, len(browser.css('.news-item')))
 
     @browsing
     def test_month_with_umlaut(self, browser):
@@ -128,4 +128,4 @@ class TestNewsArchivePortlets(FunctionalTestCase):
         self._add_portlet(browser, news_folder)
 
         browser.find(u'M\xe4rz (1)').click()
-        self.assertEqual(1, len(browser.css('li.tileItem')))
+        self.assertEqual(1, len(browser.css('.news-item')))

--- a/ftw/news/tests/test_news_detail.py
+++ b/ftw/news/tests/test_news_detail.py
@@ -27,5 +27,5 @@ class TestNewsDetail(FunctionalTestCase):
         browser.login().visit(news)
         self.assertEqual(
             'Dec 31, 2000 01:00 PM',
-            browser.css('p.newsDate').first.text
+            browser.css('.news-date').first.text
         )

--- a/ftw/news/tests/test_news_listing.py
+++ b/ftw/news/tests/test_news_listing.py
@@ -50,7 +50,7 @@ class TestNewsListing(FunctionalTestCase):
         browser.visit(self.news_folder, view='@@news_listing')
         self.assertEqual(
             'by test_user_1_',
-            browser.css('.newsListing .documentAuthor').first.text,
+            browser.css('.news-item .author').first.text,
             'Authenticated member should see author if '
             'allowAnonymousViewAbout is False.')
 
@@ -61,14 +61,14 @@ class TestNewsListing(FunctionalTestCase):
         browser.visit(self.news_folder, view='@@news_listing')
         self.assertEqual(
             'by test_user_1_',
-            browser.css('.newsListing .documentAuthor').first.text,
+            browser.css('.author').first.text,
             'Authenticated member should see author.')
 
     @browsing
     def test_anonymous_cannot_see_author_when_aava_disabled(self, browser):
         set_allow_anonymous_view_about(False)
         browser.logout().visit(self.news_folder, view='@@news_listing')
-        self.assertEquals([], browser.css('.newsListing .documentAuthor'),
+        self.assertEquals([], browser.css('.news-item .author'),
                           'Anonymous user should not see author if '
                           'allowAnonymousViewAbout is False.')
 
@@ -78,7 +78,7 @@ class TestNewsListing(FunctionalTestCase):
         browser.logout().visit(self.news_folder, view='@@news_listing')
         self.assertEqual(
             'by test_user_1_',
-            browser.css('.newsListing .documentAuthor').first.text,
+            browser.css('.author').first.text,
             'Anonymous user should see author if '
             'allowAnonymousViewAbout is True.')
 
@@ -135,7 +135,7 @@ class TestNewsListing(FunctionalTestCase):
         browser.login().visit(self.news_folder, view='news_listing')
         self.assertEqual(
             'Textblock with image',
-            browser.css('.newsListing .tileItem img').first.attrib['title']
+            browser.css('.news-item img').first.attrib['title']
         )
 
     def test_get_creator_method_does_not_fail_if_user_is_inexistent(self):

--- a/ftw/news/tests/test_news_listing_block.py
+++ b/ftw/news/tests/test_news_listing_block.py
@@ -143,7 +143,7 @@ class TestNewsListingBlockContentType(FunctionalTestCase):
                        .titled('News listing block')
                        .having(show_lead_image=True))
 
-        lead_image_css_selector = '.newsListing .tileItem .image img'
+        lead_image_css_selector = '.news-item img'
 
         browser.login().visit(page)
         self.assertEqual(
@@ -166,7 +166,7 @@ class TestNewsListingBlockContentType(FunctionalTestCase):
 
         browser.login(self.member).open(self.page)
         self.assertEqual('Dec 31, 2000 03:00 PM by test_user_1_',
-                         browser.css('.tileItem .documentByLine').first.text,
+                         browser.css('.news-item .byline').first.text,
                          'Authenticated member should see author if '
                          'allowAnonymousViewAbout is False.')
 
@@ -178,7 +178,7 @@ class TestNewsListingBlockContentType(FunctionalTestCase):
 
         browser.login(self.member).open(self.page)
         self.assertEqual('Dec 31, 2000 03:00 PM by test_user_1_',
-                         browser.css('.tileItem .documentByLine').first.text,
+                         browser.css('.news-item .byline').first.text,
                          'Authenticated member should see author.')
 
     @browsing
@@ -189,7 +189,7 @@ class TestNewsListingBlockContentType(FunctionalTestCase):
 
         browser.logout().open(self.page)
         self.assertEqual('Dec 31, 2000 03:00 PM',
-                         browser.css('.tileItem .documentByLine').first.text,
+                         browser.css('.news-item .byline').first.text,
                          'Anonymous user should not see author if '
                          'allowAnonymousViewAbout is False.')
 
@@ -201,6 +201,6 @@ class TestNewsListingBlockContentType(FunctionalTestCase):
 
         browser.logout().open(self.page)
         self.assertEqual('Dec 31, 2000 03:00 PM by test_user_1_',
-                         browser.css('.tileItem .documentByLine').first.text,
+                         browser.css('.news-item .byline').first.text,
                          'Anonymous user should see author if '
                          'allowAnonymousViewAbout is True.')

--- a/ftw/news/tests/test_news_portlets.py
+++ b/ftw/news/tests/test_news_portlets.py
@@ -45,8 +45,8 @@ class TestNewsPortlets(FunctionalTestCase):
         create(Builder('news').titled(u'Hello World').within(news_folder))
         self._add_portlet(browser, page, **{'Title': 'A News Portlet'})
 
-        self.assertEqual(1, len(browser.css('li.portletItem')))
-        self.assertIn('Hello World', browser.css('li.portletItem').first.text)
+        self.assertEqual(1, len(browser.css('.news-item')))
+        self.assertIn('Hello World', browser.css('.news-item').first.text)
 
     @browsing
     def test_add_portlet_on_plone_root(self, browser):
@@ -60,8 +60,8 @@ class TestNewsPortlets(FunctionalTestCase):
         create(Builder('news').titled(u'Hello World').within(news_folder))
         self._add_portlet(browser, self.portal, **{'Title': 'A News Portlet'})
 
-        self.assertEqual(1, len(browser.css('li.portletItem')))
-        self.assertIn('Hello World', browser.css('li.portletItem').first.text)
+        self.assertEqual(1, len(browser.css('.news-item')))
+        self.assertIn('Hello World', browser.css('.news-item').first.text)
 
     @browsing
     def test_portlet_add_form_cancel_button(self, browser):
@@ -185,7 +185,7 @@ class TestNewsPortlets(FunctionalTestCase):
         }
         self._add_portlet(browser, page2, **portlet_config)
 
-        self.assertEqual(2, len(browser.css('li.portletItem')))
+        self.assertEqual(2, len(browser.css('.news-item')))
 
     @browsing
     def test_portlet_filters_current_context(self, browser):
@@ -210,9 +210,9 @@ class TestNewsPortlets(FunctionalTestCase):
         }
         self._add_portlet(browser, page2, **portlet_config)
 
-        self.assertEqual(1, len(browser.css('li.portletItem')))
+        self.assertEqual(1, len(browser.css('.news-item')))
         self.assertIn('Hello World 2',
-                      browser.css('li.portletItem').first.text)
+                      browser.css('.news-item .title').first.text)
 
     @browsing
     def test_portlet_filters_by_path(self, browser):
@@ -238,9 +238,9 @@ class TestNewsPortlets(FunctionalTestCase):
         }
         self._add_portlet(browser, self.portal, **portlet_config)
 
-        self.assertEqual(1, len(browser.css('li.portletItem')))
+        self.assertEqual(1, len(browser.css('.news-item')))
         self.assertIn('Hello World 2',
-                      browser.css('li.portletItem').first.text)
+                      browser.css('.news-item .title').first.text)
 
     @browsing
     def test_portlet_crops_description(self, browser):
@@ -254,7 +254,7 @@ class TestNewsPortlets(FunctionalTestCase):
 
         self._add_portlet(browser, **{'Title': 'A News Portlet'})
         self.assertIn('This description must be longer than 50 ...',
-                      browser.css('li.portletItem').first.text)
+                      browser.css('.news-item .description').first.text)
 
     @browsing
     def test_portlet_does_not_render_description(self, browser):
@@ -269,7 +269,7 @@ class TestNewsPortlets(FunctionalTestCase):
         }
         self._add_portlet(browser, **portlet_config)
         self.assertIn('This description',
-                      browser.css('li.portletItem').first.text)
+                      browser.css('.news-item .description').first.text)
 
         # Tell the portlet to not render the description anymore.
         browser.visit(self.portal, view='manage-portlets')
@@ -279,7 +279,7 @@ class TestNewsPortlets(FunctionalTestCase):
         # Make sure the description is not rendered.
         browser.visit(self.portal)
         self.assertNotIn('This description',
-                         browser.css('li.portletItem').first.text)
+                         browser.css('.news-item').first.text)
 
     @browsing
     def test_portlet_filters_by_subject(self, browser):
@@ -301,9 +301,9 @@ class TestNewsPortlets(FunctionalTestCase):
         }
         self._add_portlet(browser, **portlet_config)
 
-        self.assertEqual(1, len(browser.css('li.portletItem')))
+        self.assertEqual(1, len(browser.css('.news-item .title')))
         self.assertIn('Hello World 2',
-                      browser.css('li.portletItem').first.text)
+                      browser.css('.news-item').first.text)
 
     @browsing
     def test_portlet_filters_old_news(self, browser):
@@ -328,7 +328,7 @@ class TestNewsPortlets(FunctionalTestCase):
             'Limit to current context': False,
         }
         self._add_portlet(browser, **portlet_config)
-        self.assertEquals(1, len(browser.css('li.portletItem')))
+        self.assertEquals(1, len(browser.css('.news-item')))
 
     @browsing
     def test_portlet_renders_more_link_when_enabled(self, browser):
@@ -454,9 +454,9 @@ class TestNewsPortlets(FunctionalTestCase):
         }
         self._add_portlet(browser, self.portal, **portlet_config)
 
-        self.assertEqual(1, len(browser.css('li.portletItem')))
+        self.assertEqual(1, len(browser.css('.news-item')))
         self.assertIn('Hello World 1',
-                      browser.css('li.portletItem').first.text)
+                      browser.css('.news-item .title').first.text)
 
     @browsing
     def test_news_portlet_listing_shows_more_items(self, browser):
@@ -475,11 +475,10 @@ class TestNewsPortlets(FunctionalTestCase):
         self._add_portlet(browser, page, **{'Title': 'A News Portlet',
                                             'Quantity': u'1',
                                             'Link to more news': True})
-
         browser.find('More News').click()
         self.assertEqual(
             ['Hello Again', 'Hello World'],
-            browser.css('.newsListing .tileItem .tileHeadline').text
+            browser.css('.news-listing .title').text
         )
 
     @browsing
@@ -508,7 +507,7 @@ class TestNewsPortlets(FunctionalTestCase):
                              'Quantity': u'1',
                              'Show lead image': True})
 
-        lead_image_css_selector = 'li.portletItem img'
+        lead_image_css_selector = '.news-item img'
 
         browser.login().visit(page)
         self.assertEqual(
@@ -545,7 +544,7 @@ class TestNewsPortlets(FunctionalTestCase):
 
         self.assertEqual(
             [],
-            browser.css('dl.portlet.newsTemplate li.portletFooter'),
+            browser.css('.news-portlet footer'),
             'A portlet footer has been found. But there should not be footer.'
         )
 
@@ -557,5 +556,5 @@ class TestNewsPortlets(FunctionalTestCase):
         browser.open(page)
         self.assertEqual(
             'Subscribe to the RSS feed',
-            browser.css('dl.portlet.newsTemplate li.portletFooter').first.text
+            browser.css('.news-rss').first.text
         )

--- a/ftw/news/viewlets/news_date.pt
+++ b/ftw/news/viewlets/news_date.pt
@@ -3,6 +3,6 @@
       tal:omit-tag="python: 1"
       i18n:domain="ftw.news">
 
-    <p class="newsDate" tal:condition="view/news_date" tal:content="view/news_date" />
+    <span class="news-date" tal:condition="view/news_date" tal:content="view/news_date" />
 
 </html>


### PR DESCRIPTION
Fixes https://github.com/4teamwork/demo.web/issues/4

Depends on https://github.com/4teamwork/plonetheme.blueberry/pull/26, https://github.com/4teamwork/ftw.theming/pull/39

The styling includes:
  - Standard news listing
  - News portlet
  - Simplelayout news listing block
  - News itself

![screencapture-localhost-8080-plone-news-1455617224013](https://cloud.githubusercontent.com/assets/1637820/13073468/3ff7a0a4-d49f-11e5-838c-79a9c92f2e12.png)
![screencapture-localhost-8080-plone-simplelayout-1455617212652](https://cloud.githubusercontent.com/assets/1637820/13073467/3ff46de4-d49f-11e5-8ea4-dd935a7d7e9f.png)
![bildschirmfoto 2016-02-16 um 11 18 59](https://cloud.githubusercontent.com/assets/1637820/13073476/48ad2af2-d49f-11e5-80a0-667bf4c0427b.png)
![bildschirmfoto 2016-02-16 um 10 57 01](https://cloud.githubusercontent.com/assets/1637820/13073482/4de9d290-d49f-11e5-8575-17da64b0ef46.png)
![bildschirmfoto 2016-02-16 um 10 56 50](https://cloud.githubusercontent.com/assets/1637820/13073485/5160314e-d49f-11e5-9083-89b64de3b6f1.png)
