### PR TITLE
Fix news listing block.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,9 @@ Changelog
 1.1.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- The news listing block renders news items the same way as the news portlet
+  and the news listing view.
+  [mbaechtold]
 
 
 1.1.1 (2016-03-04)

--- a/ftw/news/browser/templates/news_listing_block.pt
+++ b/ftw/news/browser/templates/news_listing_block.pt
@@ -15,31 +15,27 @@
 
         <ul class="news-row">
             <li class="news-item" tal:repeat="item news">
-                <div tal:attributes="class python:'image' if item['image_tag'] else 'no-image image'"
-                     tal:condition="block_info/show_lead_image">
-                  <img tal:condition="item/image_tag" tal:replace="structure item/image_tag" />
-                </div>
-                <div tal:attributes="class python:'body show-image' if block_info['show_lead_image'] else 'body'">
-                    <a class="title" tal:attributes="href item/url">
+                <a class="news-item" tal:attributes="href item/url">
+                    <div tal:attributes="class python:'image' if item['image_tag'] else 'no-image image'"
+                         tal:condition="block_info/show_lead_image">
+                        <img tal:condition="item/image_tag" tal:replace="structure item/image_tag" />
+                    </div>
+                    <div tal:attributes="class python:'body show-image' if block_info['show_lead_image'] else 'body'">
+                        <span class="byline">
+                            <span tal:condition="item/news_date"
+                                  tal:content="item/news_date"/>
+                            <tal:author condition="item/author">
+                                <span i18n:translate="news_listing_author_label">
+                                    by
+                                    <span tal:content="item/author"
+                                          i18n:name="author">Author</span>
+                                </span>
+                            </tal:author>
+                        </span>
                         <h3 class="title" tal:content="item/title" />
-                    </a>
-                    <span class="byline">
-                        <span tal:condition="item/news_date"
-                              tal:content="item/news_date"/>
-                        <tal:author condition="item/author">
-                            <span i18n:translate="news_listing_author_label">
-                                by
-                                <span tal:content="item/author"
-                                      i18n:name="author">Author</span>
-                            </span>
-                        </tal:author>
-                    </span>
-                    <span class="description" tal:content="item/description">Description</span>
-                    <a class="news-more"
-                       tal:attributes="href item/url"
-                       tal:condition="item/url"
-                       i18n:translate="">Read more</a>
-                </div>
+                        <span class="description" tal:content="item/description">Description</span>
+                    </div>
+                </a>
             </li>
 
         </ul>


### PR DESCRIPTION
Fixes #42

The news listing block renders news items the same way as the news portlet and the news listing view:

- the whole news item row is linked (including the image, title and description).
- the news item changes the style on hover so it becomes more obvious to the user that he can click the news item.
- the previous point is the reason why there is no `Read more...` button. It's not needed.

**Before:**

<img width="1440" alt="screenshot news 4" src="https://cloud.githubusercontent.com/assets/28220/14201102/f24ba782-f7ef-11e5-8e24-b5d7dbd8dbdc.png">


**After:**

<img width="1440" alt="screenshot news 2" src="https://cloud.githubusercontent.com/assets/28220/14201036/917c3a52-f7ef-11e5-9835-0d8dacd35908.png">

