### PR TITLE
Fix the channel link of the RSS feed.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 1.1.2 (unreleased)
 ------------------
 
+- Fix the link in the RSS feed (link to parent instead of the feed itself).
+  [mbaechtold]
+
 - The news listing block renders news items the same way as the news portlet
   and the news listing view.
   [mbaechtold]

--- a/ftw/news/browser/news_listing.py
+++ b/ftw/news/browser/news_listing.py
@@ -109,7 +109,7 @@ class NewsListingRss(NewsListing):
         This is needed because TAL complains about empty HTML tags which
         cannot use "tal:content" when building the translation messages.
         """
-        return '<link>{0}</link>'.format(self.link)
+        return '<link>{0}</link>'.format(self.context.absolute_url())
 
     def get_item_dict(self, brain):
         return {

--- a/ftw/news/tests/test_news_listing_rss.py
+++ b/ftw/news/tests/test_news_listing_rss.py
@@ -34,6 +34,18 @@ class TestNewsRssListing(FunctionalTestCase):
         self.assertEqual(1, len(view.get_items()))
 
     @browsing
+    def test_channel_link(self, browser):
+        news_folder = create(Builder('news folder'))
+
+        browser.login().visit(news_folder, view='news_listing_rss')
+
+        self.assertIn(
+            '<link>{0}</link>'.format(news_folder.absolute_url()),
+            browser.contents,
+            'Did not found the link tag of the channel'
+        )
+
+    @browsing
     def test_news_listing_rss_items(self, browser):
         news_folder = create(Builder('news folder'))
 


### PR DESCRIPTION
The link must point to the parent instead of the feed itself.