### PR TITLE
Mark news items to be shown on the homepage.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,7 +4,10 @@
 Introduction
 ============
 
-ftw.news provides dexterity content types for news articles.
+ftw.news provides dexterity content types for news articles and an integration
+for ftw.simplelayout (news listing block). An optional feature can be installed
+allowing the news listing block on the Plone Site to render specially marked
+news items only.
 
 Compatibility
 -------------
@@ -26,6 +29,11 @@ Installation
     eggs +=
         ...
         ftw.news
+
+- Install the "default" GenericSetup profile.
+
+- Optionally (and additionally to the "default" GenericSetup profile) you may
+  install the "show-on-homepage" GenericSetup profile.
 
 
 Usage

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,10 @@ Changelog
 1.1.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Adds a profile which installs an additional feature allowing to
+  mark news item to be shown on the homepage (if the news listing block
+  is configured to do so).
+  [mbaechtold]
 
 
 1.1.2 (2016-04-11)

--- a/ftw/news/behaviors/configure.zcml
+++ b/ftw/news/behaviors/configure.zcml
@@ -1,0 +1,24 @@
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    xmlns:plone="http://namespaces.plone.org/plone"
+    i18n_domain="ftw.news">
+
+    <include package="plone.behavior" file="meta.zcml" />
+
+    <plone:behavior
+        title="News on homepage"
+        description="Mark news items to show up on the homepage"
+        provides=".show_on_homepage.news.IShowOnHomepageSchema"
+        factory=".show_on_homepage.news.ShowOnHomepage"
+        marker=".show_on_homepage.news.IShowOnHomepageBehaviorMarker"
+        for="ftw.news.interfaces.INews"
+        />
+
+    <plone:behavior
+        title="News listing block on homepage"
+        description="Mark news listing block to render news on homepage"
+        provides=".show_on_homepage.news_listing_block.INewsOnHomepage"
+        for="ftw.news.interfaces.INewsListingBlock"
+        />
+
+</configure>

--- a/ftw/news/behaviors/show_on_homepage/news.py
+++ b/ftw/news/behaviors/show_on_homepage/news.py
@@ -1,0 +1,53 @@
+from ftw.news import _
+from plone.app.dexterity.behaviors import metadata
+from plone.autoform.directives import read_permission
+from plone.autoform.directives import write_permission
+from plone.directives import form
+from zope import schema
+from zope.interface import alsoProvides
+from zope.interface import Interface
+from zope.interface import noLongerProvides
+
+
+class IShowOnHomepageSchema(form.Schema):
+
+    read_permission(show_on_homepage='ftw.news.ShowNewsOnHomepage')
+    write_permission(show_on_homepage='ftw.news.ShowNewsOnHomepage')
+    show_on_homepage = schema.Bool(
+        title=_(u'label_show_on_homepage', default=u'Show on home page'),
+        description=_(
+            u'description_show_on_homepage',
+            default=u'If active, this news item may be shown on the homepage.'
+        ),
+        default=False,
+        required=False,
+    )
+
+alsoProvides(IShowOnHomepageSchema, form.IFormFieldProvider)
+
+
+class IShowOnHomepageBehaviorMarker(Interface):
+    """
+    Marker interface for the behavior.
+    """
+
+
+class IShowOnHomepage(Interface):
+    """
+    Marker interface to mark news to show up on home page. This is used
+    in the factory of the behavior.
+    """
+
+
+class ShowOnHomepage(metadata.MetadataBase):
+
+    @property
+    def show_on_homepage(self):
+        return IShowOnHomepage.providedBy(self.context)
+
+    @show_on_homepage.setter
+    def show_on_homepage(self, value):
+        if value:
+            alsoProvides(self.context, IShowOnHomepage)
+        else:
+            noLongerProvides(self.context, IShowOnHomepage)

--- a/ftw/news/behaviors/show_on_homepage/news_listing_block.py
+++ b/ftw/news/behaviors/show_on_homepage/news_listing_block.py
@@ -1,0 +1,22 @@
+from ftw.news import _
+from plone.autoform.interfaces import IFormFieldProvider
+from plone.directives import form
+from zope import schema
+from zope.interface import alsoProvides
+
+
+class INewsOnHomepage(form.Schema):
+
+    news_on_homepage = schema.Bool(
+        title=_(u'news_listing_config_news_on_homepage_label',
+                default=u'News on homepage'),
+        description=_(
+            u'news_listing_config_news_on_homepage_description',
+            default=u'Only news items which have been marked to be '
+                    u'shown on the homepage will be displayed.'),
+        default=False,
+        required=False,
+    )
+    form.order_after(news_on_homepage='current_context')
+
+alsoProvides(INewsOnHomepage, IFormFieldProvider)

--- a/ftw/news/configure.zcml
+++ b/ftw/news/configure.zcml
@@ -6,6 +6,7 @@
     xmlns:i18n="http://namespaces.zope.org/i18n"
     i18n_domain="ftw.news">
 
+    <include package=".behaviors" />
     <include package=".browser" />
     <include package=".portlets" />
     <include package=".viewlets" />
@@ -21,6 +22,14 @@
         title="ftw.news default"
         directory="profiles/default"
         description=""
+        provides="Products.GenericSetup.interfaces.EXTENSION"
+        />
+
+    <genericsetup:registerProfile
+        name="show-on-homepage"
+        title="ftw.news (show on homepage feature)"
+        directory="profiles/show_on_homepage"
+        description="Installs a feature allowing to mark news to show on homepage."
         provides="Products.GenericSetup.interfaces.EXTENSION"
         />
 

--- a/ftw/news/lawgiver.zcml
+++ b/ftw/news/lawgiver.zcml
@@ -16,4 +16,9 @@
         permissions="ftw.news: Add NewsListingBlock"
         />
 
+    <lawgiver:map_permissions
+        action_group="mark news items to show up on home page"
+        permissions="ftw.news: Mark news items to show up on home page"
+        />
+
 </configure>

--- a/ftw/news/locales/de/LC_MESSAGES/ftw.news.po
+++ b/ftw/news/locales/de/LC_MESSAGES/ftw.news.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-08-24 08:23+0000\n"
+"POT-Creation-Date: 2016-04-12 11:52+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -14,13 +14,21 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0\n"
 "Preferred-Encodings: utf-8 latin1\n"
 
+#: ./ftw/news/portlets/templates/news_archive_portlet.pt:34
+msgid "<span class=\"title\">${DYNAMIC_CONTENT}</span> <span class=\"count\">${DYNAMIC_CONTENT}</span>"
+msgstr ""
+
 #: ./ftw/news/profiles/default/types/ftw.news.NewsFolder.xml
 msgid "A container for news items."
 msgstr "Ein Behälter für News-Einträge"
 
-#: ./ftw/news/portlets/templates/news_archive_portlet.pt:10
+#: ./ftw/news/portlets/templates/news_archive_portlet.pt:9
 msgid "Archive"
 msgstr "Archiv"
+
+#: ./ftw/news/browser/configure.zcml:48
+msgid "Display the contents of a news folder."
+msgstr ""
 
 #: ./ftw/news/profiles/default/types/ftw.news.News.xml
 msgid "News"
@@ -30,6 +38,7 @@ msgstr "News-Eintrag"
 msgid "News Folder"
 msgstr "News-Verzeichnis"
 
+#: ./ftw/news/browser/configure.zcml:48
 msgid "News listing"
 msgstr "News-Auflistung"
 
@@ -37,15 +46,15 @@ msgstr "News-Auflistung"
 msgid "NewsListingBlock"
 msgstr "News-Auflistung"
 
-#: ./ftw/news/browser/templates/news_listing_block.pt:21
+#: ./ftw/news/browser/templates/news_listing_block.pt:13
 msgid "No content available"
 msgstr "Kein Inhalt verfügbar"
 
-#: ./ftw/news/browser/templates/news_listing_block.pt:51
-msgid "Read more"
-msgstr "Weiterlesen"
+#: ./ftw/news/browser/templates/news_listing.pt:9
+msgid "RSS"
+msgstr ""
 
-#: ./ftw/news/browser/templates/news_listing_block.pt:13
+#: ./ftw/news/browser/templates/news_listing_block.pt:52
 msgid "Subscribe to the RSS feed"
 msgstr "RSS abonnieren"
 
@@ -58,8 +67,12 @@ msgstr "Der Newsauflistungsblock zeigt eine konfigurierbare Liste von Nachrichte
 msgid "description_more_news_link_label"
 msgstr "Dieses Label wird nicht übersetzt."
 
+#: ./ftw/news/configure.zcml:25
+msgid "ftw.news default"
+msgstr ""
+
 #. Default: "${title} - News Feed"
-#: ./ftw/news/browser/news_listing.py:94
+#: ./ftw/news/browser/news_listing.py:90
 msgid "label_feed_desc"
 msgstr "${title} - News Feed"
 
@@ -68,31 +81,26 @@ msgstr "${title} - News Feed"
 msgid "label_more_news_link_label"
 msgstr "Label für den Link \"Weitere Einträge\""
 
-#. Default: "Read more"
-#: ./ftw/news/portlets/templates/news_portlet.pt:44
-msgid "label_readmore"
-msgstr "Weiterlesen"
-
 #. Default: "More News"
 #: ./ftw/news/browser/news_listing_block.py:32
-#: ./ftw/news/browser/templates/news_listing_block.pt:61
-#: ./ftw/news/portlets/templates/news_portlet.pt:56
+#: ./ftw/news/browser/templates/news_listing_block.pt:46
+#: ./ftw/news/portlets/templates/news_portlet.pt:37
 msgid "more_news_link_label"
 msgstr "Weitere Einträge"
 
 #. Default: "News will be sorted by this date"
-#: ./ftw/news/contents/news.py:18
+#: ./ftw/news/contents/news.py:22
 msgid "news_date_description"
 msgstr "Einträge werden nach diesem Datum sortiert"
 
 #. Default: "Date"
-#: ./ftw/news/contents/news.py:17
+#: ./ftw/news/contents/news.py:21
 msgid "news_date_label"
 msgstr "Datum des Eintrages"
 
 #. Default: "by ${author}"
-#: ./ftw/news/browser/templates/news_listing.pt:61
-#: ./ftw/news/browser/templates/news_listing_block.pt:41
+#: ./ftw/news/browser/templates/news_listing.pt:47
+#: ./ftw/news/browser/templates/news_listing_block.pt:30
 msgid "news_listing_author_label"
 msgstr "von ${author}"
 
@@ -102,102 +110,102 @@ msgid "news_listing_block_show_title_label"
 msgstr "Titel anzeigen"
 
 #. Default: "You can not filter by path and current context at the same time."
-#: ./ftw/news/contents/common.py:125
+#: ./ftw/news/contents/common.py:127
 msgid "news_listing_config_current_context_and_path_error"
 msgstr "Es nicht möglich, gleichzeitig nach Pfad und aktuellem Bereich zu filtern."
 
 #. Default: "The maximum length of the news item's description. Longer descriptions will be cropped. Enter 0 for no limitation."
-#: ./ftw/news/contents/common.py:76
+#: ./ftw/news/contents/common.py:78
 msgid "news_listing_config_description_length_description"
 msgstr "Maximale Länge der Beschreibung. Längere Beschreibungen werden gekürzt (0 = keine Einschränkung)."
 
 #. Default: "Length of the description"
-#: ./ftw/news/contents/common.py:74
+#: ./ftw/news/contents/common.py:76
 msgid "news_listing_config_description_length_label"
 msgstr "Länge der Beschreibung"
 
 #. Default: "Only show news items from the current context."
-#: ./ftw/news/contents/common.py:41
+#: ./ftw/news/contents/common.py:42
 msgid "news_listing_config_filter_current_context_description"
 msgstr "Nur Einträge aus dem aktuellen Bereich anzeigen."
 
 #. Default: "Limit to current context"
-#: ./ftw/news/contents/common.py:39
+#: ./ftw/news/contents/common.py:40
 msgid "news_listing_config_filter_current_context_label"
 msgstr "Einschränken auf aktuellen Bereich"
 
 #. Default: "Only show news items from a specific path."
-#: ./ftw/news/contents/common.py:26
+#: ./ftw/news/contents/common.py:27
 msgid "news_listing_config_filter_path_description"
 msgstr "Nur Einträge aus einem bestimmten Pfad anzeigen"
 
 #. Default: "Limit to path"
-#: ./ftw/news/contents/common.py:24
+#: ./ftw/news/contents/common.py:25
 msgid "news_listing_config_filter_path_label"
 msgstr "Auf Pfad einschränken"
 
 #. Default: "Only news younger than this value will be rendered. Enter 0 for no limitation."
-#: ./ftw/news/contents/common.py:86
+#: ./ftw/news/contents/common.py:88
 msgid "news_listing_config_maximum_age_description"
 msgstr "Nur neuere Einträge werden angezeigt (0 = keine Einschränkung)."
 
 #. Default: "Maximum age (days)"
-#: ./ftw/news/contents/common.py:84
+#: ./ftw/news/contents/common.py:86
 msgid "news_listing_config_maximum_age_label"
 msgstr "Maximales Alter (in Tagen)"
 
 #. Default: "The number of news entries to be shown at most. Enter 0 for no limitation."
-#: ./ftw/news/contents/common.py:49
+#: ./ftw/news/contents/common.py:50
 msgid "news_listing_config_quantity_description"
 msgstr "Die maximale Anzahl anzuzeigender Einträge (0 = keine Einschränkung)."
 
 #. Default: "Quantity"
-#: ./ftw/news/contents/common.py:48
+#: ./ftw/news/contents/common.py:49
 msgid "news_listing_config_quantity_label"
 msgstr "Anzahl"
 
 #. Default: "Show the description of the news item"
-#: ./ftw/news/contents/common.py:68
+#: ./ftw/news/contents/common.py:70
 msgid "news_listing_config_show_description_label"
 msgstr "Beschreibung anzeigen"
 
 #. Default: "Renders a lead image (taken from the item's first text block having an image.)"
-#: ./ftw/news/contents/common.py:114
+#: ./ftw/news/contents/common.py:116
 msgid "news_listing_config_show_lead_image_description"
 msgstr "Falls ein Textblock des Eintrages ein Bild hat, wird dieses Bild angezeigt."
 
 #. Default: "Show lead image"
-#: ./ftw/news/contents/common.py:112
+#: ./ftw/news/contents/common.py:114
 msgid "news_listing_config_show_lead_image_label"
 msgstr "Bild anzeigen"
 
 #. Default: "Render a link to a page which renders more news (only if there is at least one news item."
-#: ./ftw/news/contents/common.py:96
+#: ./ftw/news/contents/common.py:98
 msgid "news_listing_config_show_more_news_link_description"
 msgstr "Einen Link zu weiteren Einträgen anzeigen (wird nur angezeigt, wenn es mindestens einen Eintrag gibt)."
 
 #. Default: "Link to more news"
-#: ./ftw/news/contents/common.py:94
+#: ./ftw/news/contents/common.py:96
 msgid "news_listing_config_show_more_news_link_label"
 msgstr "Link zu weiteren Einträgen"
 
 #. Default: "Render a link to the RSS feed of the news."
-#: ./ftw/news/contents/common.py:106
+#: ./ftw/news/contents/common.py:108
 msgid "news_listing_config_show_rss_link_description"
 msgstr "Einen Link zum RSS-Feed der Einträge anzeigen."
 
 #. Default: "Link to RSS feed"
-#: ./ftw/news/contents/common.py:104
+#: ./ftw/news/contents/common.py:106
 msgid "news_listing_config_show_rss_link_label"
 msgstr "Link zum RSS-Feed"
 
 #. Default: "Only news with the selected subjects will be shown."
-#: ./ftw/news/contents/common.py:60
+#: ./ftw/news/contents/common.py:61
 msgid "news_listing_config_subjects_description"
 msgstr "Es werden nur Einträge angezeigt, welche mit diesen Stichworten versehen sind."
 
 #. Default: "Filter by subject"
-#: ./ftw/news/contents/common.py:58
+#: ./ftw/news/contents/common.py:59
 msgid "news_listing_config_subjects_label"
 msgstr "Nach Stichwort filtern"
 
@@ -207,14 +215,9 @@ msgid "news_listing_config_title_label"
 msgstr "Titel"
 
 #. Default: "No content available"
-#: ./ftw/news/browser/templates/news_listing.pt:39
+#: ./ftw/news/browser/templates/news_listing.pt:27
 msgid "news_listing_no_content_text"
 msgstr "Keine Inhalte vorhanden"
-
-#. Default: "Read More…"
-#: ./ftw/news/browser/templates/news_listing.pt:71
-msgid "news_listing_read_more_label"
-msgstr "Weiterlesen…"
 
 #. Default: "This portlet displays news items"
 #: ./ftw/news/portlets/news_portlet.py:34
@@ -237,33 +240,32 @@ msgid "news_portlet_always_render_portlet_label"
 msgstr "Portlet immer anzeigen"
 
 #. Default: "Cancel"
-#: ./ftw/news/portlets/news_portlet.py:250
+#: ./ftw/news/portlets/news_portlet.py:255
 msgid "news_portlet_edit_form_cancel_label"
 msgstr "Abbrechen"
 
 #. Default: "This portlet displays news items"
-#: ./ftw/news/portlets/news_portlet.py:212
+#: ./ftw/news/portlets/news_portlet.py:217
 msgid "news_portlet_edit_form_description"
 msgstr "Dieses Portlet zeigt News an"
 
 #. Default: "Edit News Portlet"
-#: ./ftw/news/portlets/news_portlet.py:211
+#: ./ftw/news/portlets/news_portlet.py:216
 msgid "news_portlet_edit_form_label"
 msgstr "News-Portlet bearbeiten"
 
 #. Default: "Save"
-#: ./ftw/news/portlets/news_portlet.py:233
+#: ./ftw/news/portlets/news_portlet.py:238
 msgid "news_portlet_edit_form_save_label"
 msgstr "Speichern"
 
 #. Default: "No recent news available."
-#: ./ftw/news/portlets/templates/news_portlet.pt:15
+#: ./ftw/news/portlets/templates/news_portlet.pt:13
 msgid "no_recent_news_label"
 msgstr "Keine Einträge vorhanden."
 
 #. Default: "Subscribe to the RSS feed"
-#: ./ftw/news/portlets/templates/news_portlet.pt:64
+#: ./ftw/news/portlets/templates/news_portlet.pt:43
 msgid "rss_link_title"
 msgstr "RSS abonnieren"
-
 

--- a/ftw/news/locales/de/LC_MESSAGES/ftw.news.po
+++ b/ftw/news/locales/de/LC_MESSAGES/ftw.news.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-04-12 11:52+0000\n"
+"POT-Creation-Date: 2016-04-12 11:56+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -30,6 +30,18 @@ msgstr "Archiv"
 msgid "Display the contents of a news folder."
 msgstr ""
 
+#: ./ftw/news/configure.zcml:34
+msgid "Installs a feature allowing to mark news to show on homepage."
+msgstr "Installiert ein zusätzliches Feature für die Anzeige von News-Einträgen auf der Startseite."
+
+#: ./ftw/news/behaviors/configure.zcml:15
+msgid "Mark news items to show up on the homepage"
+msgstr "News-Einträge für Anzeige auf Startseite markieren"
+
+#: ./ftw/news/behaviors/configure.zcml:22
+msgid "Mark news listing block to render news on homepage"
+msgstr ""
+
 #: ./ftw/news/profiles/default/types/ftw.news.News.xml
 msgid "News"
 msgstr "News-Eintrag"
@@ -41,6 +53,14 @@ msgstr "News-Verzeichnis"
 #: ./ftw/news/browser/configure.zcml:48
 msgid "News listing"
 msgstr "News-Auflistung"
+
+#: ./ftw/news/behaviors/configure.zcml:22
+msgid "News listing block on homepage"
+msgstr ""
+
+#: ./ftw/news/behaviors/configure.zcml:15
+msgid "News on homepage"
+msgstr ""
 
 #: ./ftw/news/profiles/default/types/ftw.news.NewsListingBlock.xml
 msgid "NewsListingBlock"
@@ -67,7 +87,16 @@ msgstr "Der Newsauflistungsblock zeigt eine konfigurierbare Liste von Nachrichte
 msgid "description_more_news_link_label"
 msgstr "Dieses Label wird nicht übersetzt."
 
-#: ./ftw/news/configure.zcml:25
+#. Default: "If active, this news item may be shown on the homepage."
+#: ./ftw/news/behaviors/show_on_homepage/news.py:18
+msgid "description_show_on_homepage"
+msgstr "Ermöglicht die Anzeige dieses Eintrages auf der Startseite."
+
+#: ./ftw/news/configure.zcml:34
+msgid "ftw.news (show on homepage feature)"
+msgstr ""
+
+#: ./ftw/news/configure.zcml:26
 msgid "ftw.news default"
 msgstr ""
 
@@ -81,8 +110,16 @@ msgstr "${title} - News Feed"
 msgid "label_more_news_link_label"
 msgstr "Label für den Link \"Weitere Einträge\""
 
+#. Default: "Show on home page"
+#: ./ftw/news/behaviors/show_on_homepage/news.py:17
+msgid "label_show_on_homepage"
+msgstr "Auf Startseite anzeigen"
+
+msgid "mark news items to show up on home page"
+msgstr "News-Einträge für Anzeige auf Startseite markieren"
+
 #. Default: "More News"
-#: ./ftw/news/browser/news_listing_block.py:32
+#: ./ftw/news/browser/news_listing_block.py:34
 #: ./ftw/news/browser/templates/news_listing_block.pt:46
 #: ./ftw/news/portlets/templates/news_portlet.pt:37
 msgid "more_news_link_label"
@@ -153,6 +190,16 @@ msgstr "Nur neuere Einträge werden angezeigt (0 = keine Einschränkung)."
 #: ./ftw/news/contents/common.py:86
 msgid "news_listing_config_maximum_age_label"
 msgstr "Maximales Alter (in Tagen)"
+
+#. Default: "Only news items which have been marked to be shown on the homepage will be displayed."
+#: ./ftw/news/behaviors/show_on_homepage/news_listing_block.py:13
+msgid "news_listing_config_news_on_homepage_description"
+msgstr "Zeigt nur Einträge an, bei welchen die Option \"Auf Startseite anzeigen\" aktiviert wurde"
+
+#. Default: "News on homepage"
+#: ./ftw/news/behaviors/show_on_homepage/news_listing_block.py:11
+msgid "news_listing_config_news_on_homepage_label"
+msgstr "Einträge auf Startseite"
 
 #. Default: "The number of news entries to be shown at most. Enter 0 for no limitation."
 #: ./ftw/news/contents/common.py:50

--- a/ftw/news/locales/ftw.news-manual.pot
+++ b/ftw/news/locales/ftw.news-manual.pot
@@ -16,3 +16,6 @@ msgstr ""
 
 msgid "News listing"
 msgstr ""
+
+msgid "mark news items to show up on home page"
+msgstr ""

--- a/ftw/news/locales/ftw.news.pot
+++ b/ftw/news/locales/ftw.news.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-04-12 11:52+0000\n"
+"POT-Creation-Date: 2016-04-12 11:56+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -30,6 +30,18 @@ msgstr ""
 msgid "Display the contents of a news folder."
 msgstr ""
 
+#: ./ftw/news/configure.zcml:34
+msgid "Installs a feature allowing to mark news to show on homepage."
+msgstr ""
+
+#: ./ftw/news/behaviors/configure.zcml:15
+msgid "Mark news items to show up on the homepage"
+msgstr ""
+
+#: ./ftw/news/behaviors/configure.zcml:22
+msgid "Mark news listing block to render news on homepage"
+msgstr ""
+
 #: ./ftw/news/profiles/default/types/ftw.news.News.xml
 msgid "News"
 msgstr ""
@@ -40,6 +52,14 @@ msgstr ""
 
 #: ./ftw/news/browser/configure.zcml:48
 msgid "News listing"
+msgstr ""
+
+#: ./ftw/news/behaviors/configure.zcml:22
+msgid "News listing block on homepage"
+msgstr ""
+
+#: ./ftw/news/behaviors/configure.zcml:15
+msgid "News on homepage"
 msgstr ""
 
 #: ./ftw/news/profiles/default/types/ftw.news.NewsListingBlock.xml
@@ -67,7 +87,16 @@ msgstr ""
 msgid "description_more_news_link_label"
 msgstr ""
 
-#: ./ftw/news/configure.zcml:25
+#. Default: "If active, this news item may be shown on the homepage."
+#: ./ftw/news/behaviors/show_on_homepage/news.py:18
+msgid "description_show_on_homepage"
+msgstr ""
+
+#: ./ftw/news/configure.zcml:34
+msgid "ftw.news (show on homepage feature)"
+msgstr ""
+
+#: ./ftw/news/configure.zcml:26
 msgid "ftw.news default"
 msgstr ""
 
@@ -81,8 +110,16 @@ msgstr ""
 msgid "label_more_news_link_label"
 msgstr ""
 
+#. Default: "Show on home page"
+#: ./ftw/news/behaviors/show_on_homepage/news.py:17
+msgid "label_show_on_homepage"
+msgstr ""
+
+msgid "mark news items to show up on home page"
+msgstr ""
+
 #. Default: "More News"
-#: ./ftw/news/browser/news_listing_block.py:32
+#: ./ftw/news/browser/news_listing_block.py:34
 #: ./ftw/news/browser/templates/news_listing_block.pt:46
 #: ./ftw/news/portlets/templates/news_portlet.pt:37
 msgid "more_news_link_label"
@@ -152,6 +189,16 @@ msgstr ""
 #. Default: "Maximum age (days)"
 #: ./ftw/news/contents/common.py:86
 msgid "news_listing_config_maximum_age_label"
+msgstr ""
+
+#. Default: "Only news items which have been marked to be shown on the homepage will be displayed."
+#: ./ftw/news/behaviors/show_on_homepage/news_listing_block.py:13
+msgid "news_listing_config_news_on_homepage_description"
+msgstr ""
+
+#. Default: "News on homepage"
+#: ./ftw/news/behaviors/show_on_homepage/news_listing_block.py:11
+msgid "news_listing_config_news_on_homepage_label"
 msgstr ""
 
 #. Default: "The number of news entries to be shown at most. Enter 0 for no limitation."

--- a/ftw/news/locales/ftw.news.pot
+++ b/ftw/news/locales/ftw.news.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-08-24 08:23+0000\n"
+"POT-Creation-Date: 2016-04-12 11:52+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -14,12 +14,20 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0\n"
 "Preferred-Encodings: utf-8 latin1\n"
 
+#: ./ftw/news/portlets/templates/news_archive_portlet.pt:34
+msgid "<span class=\"title\">${DYNAMIC_CONTENT}</span> <span class=\"count\">${DYNAMIC_CONTENT}</span>"
+msgstr ""
+
 #: ./ftw/news/profiles/default/types/ftw.news.NewsFolder.xml
 msgid "A container for news items."
 msgstr ""
 
-#: ./ftw/news/portlets/templates/news_archive_portlet.pt:10
+#: ./ftw/news/portlets/templates/news_archive_portlet.pt:9
 msgid "Archive"
+msgstr ""
+
+#: ./ftw/news/browser/configure.zcml:48
+msgid "Display the contents of a news folder."
 msgstr ""
 
 #: ./ftw/news/profiles/default/types/ftw.news.News.xml
@@ -30,6 +38,7 @@ msgstr ""
 msgid "News Folder"
 msgstr ""
 
+#: ./ftw/news/browser/configure.zcml:48
 msgid "News listing"
 msgstr ""
 
@@ -37,15 +46,15 @@ msgstr ""
 msgid "NewsListingBlock"
 msgstr ""
 
-#: ./ftw/news/browser/templates/news_listing_block.pt:21
+#: ./ftw/news/browser/templates/news_listing_block.pt:13
 msgid "No content available"
 msgstr ""
 
-#: ./ftw/news/browser/templates/news_listing_block.pt:51
-msgid "Read more"
+#: ./ftw/news/browser/templates/news_listing.pt:9
+msgid "RSS"
 msgstr ""
 
-#: ./ftw/news/browser/templates/news_listing_block.pt:13
+#: ./ftw/news/browser/templates/news_listing_block.pt:52
 msgid "Subscribe to the RSS feed"
 msgstr ""
 
@@ -58,8 +67,12 @@ msgstr ""
 msgid "description_more_news_link_label"
 msgstr ""
 
+#: ./ftw/news/configure.zcml:25
+msgid "ftw.news default"
+msgstr ""
+
 #. Default: "${title} - News Feed"
-#: ./ftw/news/browser/news_listing.py:94
+#: ./ftw/news/browser/news_listing.py:90
 msgid "label_feed_desc"
 msgstr ""
 
@@ -68,31 +81,26 @@ msgstr ""
 msgid "label_more_news_link_label"
 msgstr ""
 
-#. Default: "Read more"
-#: ./ftw/news/portlets/templates/news_portlet.pt:44
-msgid "label_readmore"
-msgstr ""
-
 #. Default: "More News"
 #: ./ftw/news/browser/news_listing_block.py:32
-#: ./ftw/news/browser/templates/news_listing_block.pt:61
-#: ./ftw/news/portlets/templates/news_portlet.pt:56
+#: ./ftw/news/browser/templates/news_listing_block.pt:46
+#: ./ftw/news/portlets/templates/news_portlet.pt:37
 msgid "more_news_link_label"
 msgstr ""
 
 #. Default: "News will be sorted by this date"
-#: ./ftw/news/contents/news.py:18
+#: ./ftw/news/contents/news.py:22
 msgid "news_date_description"
 msgstr ""
 
 #. Default: "Date"
-#: ./ftw/news/contents/news.py:17
+#: ./ftw/news/contents/news.py:21
 msgid "news_date_label"
 msgstr ""
 
 #. Default: "by ${author}"
-#: ./ftw/news/browser/templates/news_listing.pt:61
-#: ./ftw/news/browser/templates/news_listing_block.pt:41
+#: ./ftw/news/browser/templates/news_listing.pt:47
+#: ./ftw/news/browser/templates/news_listing_block.pt:30
 msgid "news_listing_author_label"
 msgstr ""
 
@@ -102,102 +110,102 @@ msgid "news_listing_block_show_title_label"
 msgstr ""
 
 #. Default: "You can not filter by path and current context at the same time."
-#: ./ftw/news/contents/common.py:125
+#: ./ftw/news/contents/common.py:127
 msgid "news_listing_config_current_context_and_path_error"
 msgstr ""
 
 #. Default: "The maximum length of the news item's description. Longer descriptions will be cropped. Enter 0 for no limitation."
-#: ./ftw/news/contents/common.py:76
+#: ./ftw/news/contents/common.py:78
 msgid "news_listing_config_description_length_description"
 msgstr ""
 
 #. Default: "Length of the description"
-#: ./ftw/news/contents/common.py:74
+#: ./ftw/news/contents/common.py:76
 msgid "news_listing_config_description_length_label"
 msgstr ""
 
 #. Default: "Only show news items from the current context."
-#: ./ftw/news/contents/common.py:41
+#: ./ftw/news/contents/common.py:42
 msgid "news_listing_config_filter_current_context_description"
 msgstr ""
 
 #. Default: "Limit to current context"
-#: ./ftw/news/contents/common.py:39
+#: ./ftw/news/contents/common.py:40
 msgid "news_listing_config_filter_current_context_label"
 msgstr ""
 
 #. Default: "Only show news items from a specific path."
-#: ./ftw/news/contents/common.py:26
+#: ./ftw/news/contents/common.py:27
 msgid "news_listing_config_filter_path_description"
 msgstr ""
 
 #. Default: "Limit to path"
-#: ./ftw/news/contents/common.py:24
+#: ./ftw/news/contents/common.py:25
 msgid "news_listing_config_filter_path_label"
 msgstr ""
 
 #. Default: "Only news younger than this value will be rendered. Enter 0 for no limitation."
-#: ./ftw/news/contents/common.py:86
+#: ./ftw/news/contents/common.py:88
 msgid "news_listing_config_maximum_age_description"
 msgstr ""
 
 #. Default: "Maximum age (days)"
-#: ./ftw/news/contents/common.py:84
+#: ./ftw/news/contents/common.py:86
 msgid "news_listing_config_maximum_age_label"
 msgstr ""
 
 #. Default: "The number of news entries to be shown at most. Enter 0 for no limitation."
-#: ./ftw/news/contents/common.py:49
+#: ./ftw/news/contents/common.py:50
 msgid "news_listing_config_quantity_description"
 msgstr ""
 
 #. Default: "Quantity"
-#: ./ftw/news/contents/common.py:48
+#: ./ftw/news/contents/common.py:49
 msgid "news_listing_config_quantity_label"
 msgstr ""
 
 #. Default: "Show the description of the news item"
-#: ./ftw/news/contents/common.py:68
+#: ./ftw/news/contents/common.py:70
 msgid "news_listing_config_show_description_label"
 msgstr ""
 
 #. Default: "Renders a lead image (taken from the item's first text block having an image.)"
-#: ./ftw/news/contents/common.py:114
+#: ./ftw/news/contents/common.py:116
 msgid "news_listing_config_show_lead_image_description"
 msgstr ""
 
 #. Default: "Show lead image"
-#: ./ftw/news/contents/common.py:112
+#: ./ftw/news/contents/common.py:114
 msgid "news_listing_config_show_lead_image_label"
 msgstr ""
 
 #. Default: "Render a link to a page which renders more news (only if there is at least one news item."
-#: ./ftw/news/contents/common.py:96
+#: ./ftw/news/contents/common.py:98
 msgid "news_listing_config_show_more_news_link_description"
 msgstr ""
 
 #. Default: "Link to more news"
-#: ./ftw/news/contents/common.py:94
+#: ./ftw/news/contents/common.py:96
 msgid "news_listing_config_show_more_news_link_label"
 msgstr ""
 
 #. Default: "Render a link to the RSS feed of the news."
-#: ./ftw/news/contents/common.py:106
+#: ./ftw/news/contents/common.py:108
 msgid "news_listing_config_show_rss_link_description"
 msgstr ""
 
 #. Default: "Link to RSS feed"
-#: ./ftw/news/contents/common.py:104
+#: ./ftw/news/contents/common.py:106
 msgid "news_listing_config_show_rss_link_label"
 msgstr ""
 
 #. Default: "Only news with the selected subjects will be shown."
-#: ./ftw/news/contents/common.py:60
+#: ./ftw/news/contents/common.py:61
 msgid "news_listing_config_subjects_description"
 msgstr ""
 
 #. Default: "Filter by subject"
-#: ./ftw/news/contents/common.py:58
+#: ./ftw/news/contents/common.py:59
 msgid "news_listing_config_subjects_label"
 msgstr ""
 
@@ -207,13 +215,8 @@ msgid "news_listing_config_title_label"
 msgstr ""
 
 #. Default: "No content available"
-#: ./ftw/news/browser/templates/news_listing.pt:39
+#: ./ftw/news/browser/templates/news_listing.pt:27
 msgid "news_listing_no_content_text"
-msgstr ""
-
-#. Default: "Read More…"
-#: ./ftw/news/browser/templates/news_listing.pt:71
-msgid "news_listing_read_more_label"
 msgstr ""
 
 #. Default: "This portlet displays news items"
@@ -237,33 +240,32 @@ msgid "news_portlet_always_render_portlet_label"
 msgstr ""
 
 #. Default: "Cancel"
-#: ./ftw/news/portlets/news_portlet.py:250
+#: ./ftw/news/portlets/news_portlet.py:255
 msgid "news_portlet_edit_form_cancel_label"
 msgstr ""
 
 #. Default: "This portlet displays news items"
-#: ./ftw/news/portlets/news_portlet.py:212
+#: ./ftw/news/portlets/news_portlet.py:217
 msgid "news_portlet_edit_form_description"
 msgstr ""
 
 #. Default: "Edit News Portlet"
-#: ./ftw/news/portlets/news_portlet.py:211
+#: ./ftw/news/portlets/news_portlet.py:216
 msgid "news_portlet_edit_form_label"
 msgstr ""
 
 #. Default: "Save"
-#: ./ftw/news/portlets/news_portlet.py:233
+#: ./ftw/news/portlets/news_portlet.py:238
 msgid "news_portlet_edit_form_save_label"
 msgstr ""
 
 #. Default: "No recent news available."
-#: ./ftw/news/portlets/templates/news_portlet.pt:15
+#: ./ftw/news/portlets/templates/news_portlet.pt:13
 msgid "no_recent_news_label"
 msgstr ""
 
 #. Default: "Subscribe to the RSS feed"
-#: ./ftw/news/portlets/templates/news_portlet.pt:64
+#: ./ftw/news/portlets/templates/news_portlet.pt:43
 msgid "rss_link_title"
 msgstr ""
-
 

--- a/ftw/news/permissions.zcml
+++ b/ftw/news/permissions.zcml
@@ -17,4 +17,9 @@
         title="ftw.news: Add NewsListingBlock"
         />
 
+    <permission
+        id="ftw.news.ShowNewsOnHomepage"
+        title="ftw.news: Mark news items to show up on home page"
+        />
+
 </configure>

--- a/ftw/news/profiles/show_on_homepage/metadata.xml
+++ b/ftw/news/profiles/show_on_homepage/metadata.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<metadata>
+    <version>1000</version>
+    <dependencies>
+    </dependencies>
+</metadata>

--- a/ftw/news/profiles/show_on_homepage/rolemap.xml
+++ b/ftw/news/profiles/show_on_homepage/rolemap.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+<rolemap>
+    <permissions>
+
+        <permission name="ftw.news: Mark news items to show up on home page" acquire="True">
+            <role name="Manager"/>
+            <role name="Site Administrator"/>
+        </permission>
+
+    </permissions>
+</rolemap>

--- a/ftw/news/profiles/show_on_homepage/types/ftw.news.News.xml
+++ b/ftw/news/profiles/show_on_homepage/types/ftw.news.News.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<object name="ftw.news.News">
+
+    <property name="behaviors" purge="False">
+        <element value="ftw.news.behaviors.show_on_homepage.news.IShowOnHomepageSchema" />
+    </property>
+
+</object>

--- a/ftw/news/profiles/show_on_homepage/types/ftw.news.NewsListingBlock.xml
+++ b/ftw/news/profiles/show_on_homepage/types/ftw.news.NewsListingBlock.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<object name="ftw.news.NewsListingBlock">
+
+    <property name="behaviors" purge="False">
+        <element value="ftw.news.behaviors.show_on_homepage.news_listing_block.INewsOnHomepage" />
+    </property>
+
+</object>

--- a/ftw/news/tests/test_news_on_homepage_behavior.py
+++ b/ftw/news/tests/test_news_on_homepage_behavior.py
@@ -1,0 +1,77 @@
+from datetime import datetime
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.news.behaviors.show_on_homepage.news import IShowOnHomepage
+from ftw.news.behaviors.show_on_homepage.news import IShowOnHomepageSchema
+from ftw.news.tests import FunctionalTestCase
+from ftw.testbrowser import browsing
+from plone.app.testing import applyProfile
+from zope.interface import directlyProvidedBy
+from zope.interface import directlyProvides
+from zope.interface import Interface
+
+
+class TestNewsOnHomepageBehavior(FunctionalTestCase):
+
+    def setUp(self):
+        super(TestNewsOnHomepageBehavior, self).setUp()
+        self.grant('Manager')
+
+    @browsing
+    def test_show_on_home_field_is_protected(self, browser):
+        applyProfile(self.portal, 'ftw.news:show-on-homepage')
+
+        page = create(Builder('sl content page'))
+        newsfolder = create(Builder('news folder').within(page))
+        news = create(Builder('news')
+                      .within(newsfolder)
+                      .having(news_date=datetime(2011, 1, 2, 15, 0, 0)))
+
+        field_label = 'Show on home page'
+
+        browser.login().visit(news, view='edit')
+        self.assertIn(
+            field_label,
+            browser.forms['form'].field_labels,
+            "The manager must be able to mark news to be shown on the"
+            "homepage,"
+        )
+
+        user = create(Builder('user').with_roles('Editor'))
+        browser.login(user).visit(news, view='edit')
+        self.assertNotIn(
+            field_label,
+            browser.forms['form'].field_labels,
+            "An editor must not be able to mark news to be shown on the"
+            "homepage."
+        )
+
+    def test_show_on_home_factory_does_not_remove_other_interfaces(self):
+        applyProfile(self.portal, 'ftw.news:show-on-homepage')
+
+        page = create(Builder('sl content page'))
+        newsfolder = create(Builder('news folder').within(page))
+        news = create(Builder('news')
+                      .within(newsfolder)
+                      .having(news_date=datetime(2011, 1, 2, 15, 0, 0)))
+
+        class IDummyMarkerInterface(Interface):
+            pass
+
+        directlyProvides(news, IDummyMarkerInterface)
+        self.assertEqual(
+            [IDummyMarkerInterface],
+            list(directlyProvidedBy(news))
+        )
+
+        IShowOnHomepageSchema(news).show_on_homepage = True
+        self.assertEqual(
+            [IDummyMarkerInterface, IShowOnHomepage],
+            list(directlyProvidedBy(news))
+        )
+
+        IShowOnHomepageSchema(news).show_on_homepage = False
+        self.assertEqual(
+            [IDummyMarkerInterface],
+            list(directlyProvidedBy(news))
+        )


### PR DESCRIPTION
Adds a profile which installs an additional feature allowing to mark news item to be shown on the homepage. A news listing block on the Plone Site can then be configured to render only news items marked accordingly.