### PR TITLE
Adjust date and time

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,10 @@ Changelog
 1.1.3 (unreleased)
 ------------------
 
+- Adjusts the date and time displayed for each news item in a news folder.
+  Doesnt show time if there is no time set.
+  [raphael-s]
+  
 - Adds a profile which installs an additional feature allowing to
   mark news item to be shown on the homepage (if the news listing block
   is configured to do so).

--- a/ftw/news/browser/news_listing.py
+++ b/ftw/news/browser/news_listing.py
@@ -1,21 +1,23 @@
-from Acquisition import aq_parent, aq_inner
+from Acquisition import aq_inner
+from Acquisition import aq_parent
+from DateTime import DateTime
+from ftw.news import _
+from ftw.news import utils
+from ftw.news.interfaces import INewsFolder
+from ftw.news.interfaces import INewsListingView
+from plone.portlets.interfaces import IPortletAssignmentMapping
+from plone.portlets.interfaces import IPortletManager
+from plone.portlets.interfaces import IPortletRenderer
 from Products.CMFCore.permissions import AccessInactivePortalContent
 from Products.CMFCore.utils import _checkPermission
 from Products.CMFCore.utils import getToolByName
 from Products.CMFPlone.interfaces import IPloneSiteRoot
 from Products.CMFPlone.PloneBatch import Batch
 from Products.Five.browser import BrowserView
-from ftw.news import _
-from ftw.news import utils
-from ftw.news.interfaces import INewsListingView, INewsFolder
-from plone.portlets.interfaces import IPortletAssignmentMapping
-from plone.portlets.interfaces import IPortletManager
-from plone.portlets.interfaces import IPortletRenderer
 from zope.component import getMultiAdapter
 from zope.component import getUtility
 from zope.component import queryMultiAdapter
 from zope.interface import implements
-import DateTime
 
 
 class NewsListing(BrowserView):
@@ -41,10 +43,10 @@ class NewsListing(BrowserView):
         datestring = self.request.get('archive')
         if datestring:
             try:
-                start = DateTime.DateTime(datestring)
+                start = DateTime(datestring)
             except DateTime.interfaces.SyntaxError:
                 raise
-            end = DateTime.DateTime('{0}/{1}/{2}'.format(
+            end = DateTime('{0}/{1}/{2}'.format(
                 start.year() + start.month() / 12,
                 start.month() % 12 + 1,
                 1)
@@ -92,7 +94,8 @@ class NewsListing(BrowserView):
                  mapping={'title': self.context.Title().decode('utf-8')})
 
     def format_date(self, brain):
-        return self.context.toLocalizedTime(brain.start, long_format=True)
+        show_long_format = DateTime(brain.start).hour() or DateTime(brain.start).minute()
+        return self.context.toLocalizedTime(brain.start, long_format=show_long_format)
 
 
 class NewsListingRss(NewsListing):

--- a/ftw/news/tests/test_news_listing.py
+++ b/ftw/news/tests/test_news_listing.py
@@ -1,4 +1,6 @@
-from datetime import timedelta, datetime
+from DateTime import DateTime
+from datetime import datetime
+from datetime import timedelta
 from ftw.builder import Builder
 from ftw.builder import create
 from ftw.news.testing import FTW_NEWS_FUNCTIONAL_TESTING
@@ -147,3 +149,51 @@ class TestNewsListing(FunctionalTestCase):
                       .having(news_date=datetime.now()))
         news.Creator = userid
         self.assertEquals(userid, get_creator(news))
+
+class TestNewsListingFormat(FunctionalTestCase):
+
+    def setUp(self):
+        super(TestNewsListingFormat, self).setUp()
+        self.grant('Manager')
+
+        self.news_folder = create(Builder('news folder'))
+
+    @browsing
+    def test_show_full_creation_date_if_hour_and_minute_are_set(self, browser):
+        create(Builder('news')
+            .within(self.news_folder)
+            .having(news_date=DateTime('2015/03/13 16:15')))
+
+        browser.login().open(self.news_folder)
+
+        self.assertEquals('Mar 13, 2015 04:15 PM', browser.css('.dtstart').first.text)
+
+    @browsing
+    def test_show_full_creation_date_if_minute_is_not_set(self, browser):
+        create(Builder('news')
+            .within(self.news_folder)
+            .having(news_date=DateTime('2015/03/13 16:00')))
+
+        browser.login().open(self.news_folder)
+
+        self.assertEquals('Mar 13, 2015 04:00 PM', browser.css('.dtstart').first.text)
+
+    @browsing
+    def test_show_full_creation_date_if_hour_is_not_set(self, browser):
+        create(Builder('news')
+            .within(self.news_folder)
+            .having(news_date=DateTime('2015/03/13 00:15')))
+
+        browser.login().open(self.news_folder)
+
+        self.assertEquals('Mar 13, 2015 12:15 AM', browser.css('.dtstart').first.text)
+
+    @browsing
+    def test_show_no_time_if_minute_and_hour_are_not_set(self, browser):
+        create(Builder('news')
+            .within(self.news_folder)
+            .having(news_date=DateTime('2015/03/13 00:00')))
+
+        browser.login().open(self.news_folder)
+
+        self.assertEquals('Mar 13, 2015', browser.css('.dtstart').first.text)


### PR DESCRIPTION
Adjusts the date and time displayed for each news item in a news folder.
Doesnt show time if there is no time set.

![bildschirmfoto 2016-04-13 um 17 30 55](https://cloud.githubusercontent.com/assets/16755391/14499178/812c6728-019d-11e6-9175-240f8ecab3d1.png)

closes #50 
