### PR TITLE
Based on user feedback the huge news title is not desirable.

### DIFF
--- a/ftw/news/browser/resources/news.scss
+++ b/ftw/news/browser/resources/news.scss
@@ -70,7 +70,8 @@ $leadimage-max-width: 200px !default;
     }
 
     .title {
-      font-size: $font-size-h3;
+      font-size: 1rem;
+      font-weight: bold;
       display: block;
     }
   }


### PR DESCRIPTION
Closes https://github.com/4teamwork/bl.web/issues/105

<img width="1178" alt="bildschirmfoto 2016-04-15 um 09 55 36" src="https://cloud.githubusercontent.com/assets/1637820/14554984/4c9cbf9a-02f0-11e6-8be3-f4d8a591347c.png">