### PR TITLE
Adjust date and time formatting

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,10 @@ Changelog
 1.1.4 (unreleased)
 ------------------
 
+- Adjusts the formatting of the date and time displayed on the page of a news item.
+  Time doesn't show up if it is set to 00:00.
+  [raphael-s]
+
 - Call news_listing view on NewsListingBlock and optain query from block for news listing.
   [mathias.leimgruber]
 

--- a/ftw/news/tests/test_news_detail.py
+++ b/ftw/news/tests/test_news_detail.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from DateTime import DateTime
 from ftw.builder import Builder
 from ftw.builder import create
 from ftw.news.testing import FTW_NEWS_FUNCTIONAL_TESTING
@@ -29,3 +30,51 @@ class TestNewsDetail(FunctionalTestCase):
             'Dec 31, 2000 01:00 PM',
             browser.css('.news-date').first.text
         )
+
+class TestDateTimeFormat(FunctionalTestCase):
+
+    def setUp(self):
+        super(TestDateTimeFormat, self).setUp()
+        self.grant('Manager')
+
+        self.news_folder = create(Builder('news folder'))
+
+    @browsing
+    def test_show_full_creation_date_if_hour_and_minute_are_set(self, browser):
+        news = create(Builder('news')
+            .within(self.news_folder)
+            .having(news_date=DateTime('2015/03/13 16:15')))
+
+        browser.login().open(news)
+
+        self.assertEquals('Mar 13, 2015 04:15 PM', browser.css('.news-date').first.text)
+
+    @browsing
+    def test_show_full_creation_date_if_minute_is_not_set(self, browser):
+        news = create(Builder('news')
+            .within(self.news_folder)
+            .having(news_date=DateTime('2015/03/13 16:00')))
+
+        browser.login().open(news)
+
+        self.assertEquals('Mar 13, 2015 04:00 PM', browser.css('.news-date').first.text)
+
+    @browsing
+    def test_show_full_creation_date_if_hour_is_not_set(self, browser):
+        news = create(Builder('news')
+            .within(self.news_folder)
+            .having(news_date=DateTime('2015/03/13 00:15')))
+
+        browser.login().open(news)
+
+        self.assertEquals('Mar 13, 2015 12:15 AM', browser.css('.news-date').first.text)
+
+    @browsing
+    def test_show_no_time_if_minute_and_hour_are_not_set(self, browser):
+        news = create(Builder('news')
+            .within(self.news_folder)
+            .having(news_date=DateTime('2015/03/13 00:00')))
+
+        browser.login().open(news)
+
+        self.assertEquals('Mar 13, 2015', browser.css('.news-date').first.text)

--- a/ftw/news/viewlets/news_date.py
+++ b/ftw/news/viewlets/news_date.py
@@ -1,6 +1,7 @@
-from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
+from DateTime import DateTime
 from ftw.news.contents.news import INewsSchema
 from plone.app.layout.viewlets import ViewletBase
+from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 
 
 class NewsDateViewlet(ViewletBase):
@@ -20,4 +21,5 @@ class NewsDateViewlet(ViewletBase):
         if not news_date:
             return ''
 
-        return self.context.toLocalizedTime(news_date, long_format=True)
+        show_long_format = DateTime(news_date).hour() or DateTime(news_date).minute()
+        return self.context.toLocalizedTime(news_date, long_format=show_long_format)


### PR DESCRIPTION
Adjusts the formattion of date and time on the page of a news item. 
Time doensn't show up if set to 00:00.

![bildschirmfoto 2016-04-25 um 11 36 51](https://cloud.githubusercontent.com/assets/16755391/14779795/06da7046-0ada-11e6-9b00-7bdafe4ed985.png)
