### PR TITLE
Add a wrapper class to the news footer action on the news listing block.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,9 @@ Changelog
 1.1.5 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Add a wrapper class to the news footer action on the news listing block.
+  The news listing portlte allready has one. This makes styling the actions more easier.
+  [mathias.leimgruber]
 
 
 1.1.4 (2016-05-20)

--- a/ftw/news/browser/templates/news_listing_block.pt
+++ b/ftw/news/browser/templates/news_listing_block.pt
@@ -43,16 +43,19 @@
         <tal:footer tal:define="more_news_link_url block_info/more_news_link_url;
                                 more_news_link_label block_info/more_news_link_label;
                                 rss_url block_info/rss_link_url">
-            <a class="news-more"
-               tal:condition="more_news_link_url"
-               title="More News"
-               i18n:attributes="title more_news_link_label"
-               tal:attributes="href more_news_link_url"
-               tal:content="more_news_link_label"/>
-            <a class="news-rss"
-               tal:condition="rss_url"
-               tal:attributes="href rss_url"
-               i18n:translate="">Subscribe to the RSS feed</a>
+            <div class="news-footer"
+                 tal:condition="python: more_news_link_url or rss_url">
+                    <a class="news-more"
+                       tal:condition="more_news_link_url"
+                       title="More News"
+                       i18n:attributes="title more_news_link_label"
+                       tal:attributes="href more_news_link_url"
+                       tal:content="more_news_link_label"/>
+                    <a class="news-rss"
+                       tal:condition="rss_url"
+                       tal:attributes="href rss_url"
+                       i18n:translate="">Subscribe to the RSS feed</a>
+               </div>
         </tal:footer>
 
     </tal:news>


### PR DESCRIPTION
The news listing portlte allready has one. This makes styling the actions more easier.