### PR TITLE
Fix link "Link to more news".

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,12 @@ Changelog
 1.1.6 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix link "Link to more news".
+  If you click on the link it will open the view "news_listing" on the context
+  to list all news in the given path. The view should be called on the contentpage (parent)
+  instead the block itself. Otherwise the url will be wired and the attributes are not set
+  correctly on the view.
+  [elioschmutz]
 
 
 1.1.5 (2016-07-07)

--- a/ftw/news/browser/news_listing_block.py
+++ b/ftw/news/browser/news_listing_block.py
@@ -26,7 +26,8 @@ class NewsListingBlockView(BaseBlock):
 
         more_news_link_url = ''
         if self.context.show_more_news_link:
-            more_news_link_url = '/'.join([self.context.absolute_url(), 'news_listing'])
+            parent = aq_parent(aq_inner((self.context)))
+            more_news_link_url = '/'.join([parent.absolute_url(), 'news_listing'])
 
         more_news_link_label = (
             self.context.more_news_link_label or

--- a/ftw/news/tests/test_news_listing_block.py
+++ b/ftw/news/tests/test_news_listing_block.py
@@ -78,6 +78,22 @@ class TestNewsListingBlockContentType(FunctionalTestCase):
                          browser.find('More News').text)
 
     @browsing
+    def test_news_listing_block_link_to_more_news_links_to_view_on_parent(self, browser):
+        page = create(Builder('sl content page').titled(u'A page'))
+
+        create(Builder('news listing block')
+               .within(page)
+               .titled(u'News listing block')
+               .having(show_more_news_link=True))
+
+        browser.login().visit(page)
+        browser.find('More News').click()
+
+        self.assertEqual(
+            '{}/news_listing'.format(page.absolute_url()),
+            browser.url)
+
+    @browsing
     def test_news_listing_block_more_news_link_custom_label(self, browser):
         page = create(Builder('sl content page').titled(u'A page'))
 


### PR DESCRIPTION
If you click on the link it will open the view "news_listing" on the context
to list all news in the given path. The view should be called on the contentpage (parent)
instead the block itself. Otherwise the url will be wired and the attributes are not set
correctly on the view.