### PR TITLE
Implement "mopage.news.xml" API browser view.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,8 @@ Changelog
 1.2.0 (unreleased)
 ------------------
 
+- Implement "mopage.news.xml" API browser view. [jone]
+
 - Enable IExcludeFromNavigation behavior for news folders. [jone]
 
 - Enable IPublication behavior for news. [jone]

--- a/ftw/news/browser/configure.zcml
+++ b/ftw/news/browser/configure.zcml
@@ -63,4 +63,12 @@
         action="news_listing"
         />
 
+    <browser:page
+        for="*"
+        name="mopage.news.xml"
+        class=".mopage.MopageNews"
+        template="templates/mopage_news.pt"
+        permission="zope2.View"
+        />
+
 </configure>

--- a/ftw/news/browser/mopage.py
+++ b/ftw/news/browser/mopage.py
@@ -1,0 +1,165 @@
+from DateTime import DateTime
+from plone.app.dexterity.behaviors.metadata import ICategorization
+from plone.uuid.interfaces import IUUID
+from Products.CMFCore.utils import getToolByName
+from Products.Five.browser import BrowserView
+from zExceptions import BadRequest
+import lxml.html
+import math
+import re
+import urllib
+import urlparse
+
+
+def normalize_whitespace(text, replacement=' '):
+    text = re.sub(r'^\s+', replacement, text)
+    text = re.sub(r'\s+$', replacement, text)
+    return text
+
+
+def normalize_join(*parts):
+    return normalize_whitespace(''.join([part or '' for part in parts]))
+
+
+def remove_node(node):
+    parent = node.getparent()
+    if parent is None:
+        return
+
+    position = parent.index(node)
+
+    if position == 0:
+        parent.text = normalize_join(parent.text, node.tail)
+    else:
+        sibling = parent[position - 1]
+        sibling.tail = normalize_join(sibling.tail, node.tail)
+
+    parent.remove(node)
+
+
+def crop(length, text):
+    if not text:
+        return text
+
+    text = text.decode('utf-8')
+    if len(text) > length:
+        text = text[:length - 5] + ' ...'
+    return text.encode('utf-8')
+
+
+class MopageNews(BrowserView):
+    """Documentation: http://doc.mopage.ch/ext/XML_Schnittstelle/2_XML_Aufbau
+    """
+
+    def __call__(self):
+        self.request.RESPONSE.setHeader('Cache-Control', 'no-store')
+        return super(MopageNews, self).__call__()
+
+    def import_node_attributes(self):
+        attrs = {'export_time': self.normalize_date(DateTime())}
+        for name in ('partner', 'partnerid', 'passwort', 'importid', 'vaterobjekt'):
+            attrs[name] = self.request.form.get(name, None)
+        return attrs
+
+    def items(self):
+        brains = self.apply_pagination(self.get_brains())
+        return map(self.brain_to_item, brains)
+
+    def get_brains(self):
+        catalog = getToolByName(self.context, 'portal_catalog')
+        return catalog(self.get_query())
+
+    def apply_pagination(self, brains):
+        per_page = self.get_int_param_from_request('per_page', 100)
+        page = self.get_int_param_from_request('page', 1)
+        last = page * per_page
+        first = last - per_page
+        batch = brains[first:last]
+
+        links = []
+        if page > 1:
+            links.append(self.build_pagination_link('first', page=1))
+            links.append(self.build_pagination_link('prev', page=page-1))
+
+        if len(brains) > last:
+            links.append(self.build_pagination_link('next', page=int(page+1)))
+            links.append(self.build_pagination_link(
+                'last', page=int(math.ceil(len(brains) / float(per_page)))))
+
+        if links:
+            self.request.RESPONSE.setHeader('Link', ','.join(links))
+
+        return batch
+
+    def get_query(self):
+        return {
+            'object_provides': 'ftw.news.interfaces.INews',
+            'sort_on': 'start',
+            'sort_order': 'reverse',
+            'path': '/'.join(self.context.getPhysicalPath())}
+
+    def brain_to_item(self, brain):
+        obj = brain.getObject()
+        image_url = self.get_lead_image_url(obj)
+
+        if image_url and len(image_url) > 255:
+            # sorry, not supported.
+            image_url = None
+
+        textlead = crop(100, obj.Description() or '')
+        if textlead:
+            textlead = u'<![CDATA[{}]]>'.format(textlead)
+
+        return {'title': crop(100, brain.Title),
+                'news_date': self.normalize_date(brain.start),
+                'expires': self.normalize_date(brain.expires),
+                'modified_date': self.normalize_date(brain.modified),
+                'uid': IUUID(obj),
+                'url': brain.getURL(),
+                'textlead': textlead,
+                'image_url': image_url,
+                'subjects': map(lambda subject: crop(100, subject),
+                                ICategorization(obj).subjects),
+                'obj': obj}
+
+    def normalize_date(self, date):
+        if not date:
+            return ''
+
+        if DateTime(date) > DateTime(2100, 1, 1):
+            return None
+
+        return date.strftime('%Y-%m-%d %H:%M:%S')
+
+    def html_to_text(self, html):
+        doc = lxml.html.fromstring(html)
+        map(remove_node, doc.xpath(
+            '//*[contains(concat(" ", normalize-space(@class), " "), '
+            '" hiddenStructure ")]'))
+        html = lxml.etree.tostring(doc, pretty_print=True)
+
+        portal_transforms = getToolByName(self.context, 'portal_transforms')
+        data = portal_transforms.convertTo('text/x-web-intelligent',
+                                           html,
+                                           mimetype='text/html')
+        text = data.getData().strip()
+        text = crop(10000, text)
+        return u'<![CDATA[' + text + u']]>'
+
+    def get_lead_image_url(self, news):
+        scale = news.restrictedTraverse('@@leadimage').get_scale()
+        return scale and scale.url or None
+
+    def get_int_param_from_request(self, name, default):
+        value = int(self.request.get(name, default))
+        if value < 1:
+            raise BadRequest('Invalid "{}" parameter value.'.format(name))
+        return value
+
+    def build_pagination_link(self, rel, **kwargs):
+        params = self.request.form.copy()
+        params.update(kwargs)
+        parts = list(urlparse.urlparse(self.request.ACTUAL_URL))
+        parts[4] = urllib.urlencode(params)
+        url = urlparse.urlunparse(parts)
+        return '<{}>; rel="{}"'.format(url, rel)

--- a/ftw/news/browser/templates/mopage_news.pt
+++ b/ftw/news/browser/templates/mopage_news.pt
@@ -1,0 +1,32 @@
+<?xml version='1.0' encoding='utf-8'?>
+<import xmlns:tal="http://xml.zope.org/namespaces/tal"
+        xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+        i18n:domain="ftw.news"
+        tal:define="attrs view/import_node_attributes"
+        tal:attributes="export_time attrs/export_time;
+                        partner attrs/partner;
+                        partnerid attrs/partnerid;
+                        passwort attrs/passwort;
+                        importid attrs/importid;
+                        vaterobjekt attrs/vaterobjekt">
+
+    <item tal:repeat="item view/items"
+          tal:attributes="datumvon item/news_date;
+                          datumbis item/expires;
+                          mutationsdatum item/modified_date"
+          status="1"
+          suchbar="1">
+        <id tal:content="item/uid" />
+        <url_web tal:content="item/url" />
+        <titel tal:content="item/title" />
+        <textlead tal:content="item/textlead" />
+        <url_bild tal:content="item/image_url" tal:condition="item/image_url" />
+        <textmobile tal:define="context nocall:item/obj;
+                                html simplelayout:default">
+            <tal:TEXT replace="structure python:view.html_to_text(html)" />
+        </textmobile>
+        <rubrik tal:repeat="subject item/subjects"
+                tal:content="subject" />
+    </item>
+
+</import>

--- a/ftw/news/tests/__init__.py
+++ b/ftw/news/tests/__init__.py
@@ -1,4 +1,6 @@
+from StringIO import StringIO
 from ftw.news.testing import FTW_NEWS_FUNCTIONAL_TESTING
+from lxml import etree
 from plone.app.testing import setRoles
 from plone.app.testing import TEST_USER_ID
 from unittest2 import TestCase
@@ -14,3 +16,37 @@ class FunctionalTestCase(TestCase):
     def grant(self, *roles):
         setRoles(self.portal, TEST_USER_ID, list(roles))
         transaction.commit()
+
+
+class XMLDiffTestCase(TestCase):
+
+    def _canonicalize_xml(self, text, node_sorter=None):
+        parser = etree.XMLParser(remove_blank_text=True)
+        try:
+            xml = etree.fromstring(text, parser)
+        except etree.XMLSyntaxError, exc:
+            print '-' * 10
+            print exc.error_log
+            print '-' * 10
+            print text
+            print '-' * 10
+            raise
+
+        norm = StringIO()
+        if node_sorter:
+            # Search for parent elements
+            for parent in xml.xpath('//*[./*]'):
+                parent[:] = sorted(parent, node_sorter)
+
+        xml.getroottree().write_c14n(norm)
+        xml = etree.fromstring(norm.getvalue())
+        return etree.tostring(xml.getroottree(),
+                              pretty_print=True,
+                              xml_declaration=True,
+                              encoding='utf-8')
+
+    def assert_xml(self, xml1, xml2):
+        norm1 = self._canonicalize_xml(xml1)
+        norm2 = self._canonicalize_xml(xml2)
+        self.maxDiff = None
+        self.assertMultiLineEqual(norm1, norm2)

--- a/ftw/news/tests/mopage_assets/01_export_news.xml
+++ b/ftw/news/tests/mopage_assets/01_export_news.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="iso-8859-15" ?>
+<import export_time="2011-01-02 03:04:00">
+
+    <item status="1" suchbar="1" mutationsdatum="2010-05-17 16:34:00" datumvon="2010-05-18 12:00:00" datumbis="2020-01-01 00:00:00">
+        <id>uid00000000000000000000000000004</id>
+        <url_web>http://nohost/plone/news-folder/largest-aircraft-in-the-world</url_web>
+        <titel>Largest Aircraft in the World</titel>
+        <textlead></textlead>
+
+        <textmobile>
+            <![CDATA[]]>
+        </textmobile>
+    </item>
+    <item status="1" suchbar="1" mutationsdatum="2010-03-14 20:18:00" datumvon="2010-03-15 12:00:00">
+        <id>uid00000000000000000000000000002</id>
+        <url_web>http://nohost/plone/news-folder/usain-bolt-at-the-olympics</url_web>
+        <titel>Usain Bolt at the Olympics</titel>
+        <textlead>&lt;![CDATA[Usain Bolt wins the Olympic gold in three events.
+
+The third is for a 100-metre relay.]]&gt;</textlead>
+        <url_bild>http://nohost/plone/news-folder/usain-bolt-at-the-olympics/ftw-simplelayout-textblock/image.jpg</url_bild>
+        <textmobile>
+            <![CDATA[Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sapientem locupletat ipsa natura, cuius divitias Epicurus parabiles esse docuit. Multa sunt dicta ab antiquis de contemnendis ac despiciendis rebus humanis.
+
+ Lorem ipsum dolor sit amet, consectetur adipiscing elit. At certe gravius. Ut optime, secundum naturam affectum esse possit. Quia dolori non voluptas contraria est, sed doloris privatio. Non minor, inquit, voluptas percipitur ex vilissimis rebus quam ex pretiosissimis. Sed nunc, quod agimus; Duo Reges: constructio interrete.]]>
+        </textmobile>
+        <rubrik>Homepage</rubrik>
+        <rubrik>Sports</rubrik>
+    </item>
+
+</import>

--- a/ftw/news/tests/mopage_assets/lorem1.html
+++ b/ftw/news/tests/mopage_assets/lorem1.html
@@ -1,0 +1,2 @@
+<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sapientem locupletat ipsa natura, cuius divitias <b>Epicurus</b> parabiles esse docuit. Multa sunt dicta ab antiquis de contemnendis ac despiciendis rebus humanis.</p>
+<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. At certe gravius. Ut optime, secundum naturam affectum esse possit. Quia dolori non voluptas contraria est, sed doloris privatio. Non minor, inquit, voluptas percipitur ex vilissimis rebus quam ex pretiosissimis. Sed nunc, quod agimus; Duo Reges: constructio interrete.</p>

--- a/ftw/news/tests/test_mopage.py
+++ b/ftw/news/tests/test_mopage.py
@@ -1,0 +1,160 @@
+from datetime import datetime
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.news.tests import FunctionalTestCase
+from ftw.news.tests import utils
+from ftw.news.tests import XMLDiffTestCase
+from ftw.testbrowser import browser
+from ftw.testbrowser import browsing
+from ftw.testing import freeze
+from ftw.testing import staticuid
+from path import Path
+from plone.app.textfield import RichTextValue
+import re
+
+
+class TestMopageExport(FunctionalTestCase, XMLDiffTestCase):
+
+    @staticuid('uid')
+    @browsing
+    def test_01_export_news(self, browser):
+        self.grant('Manager')
+        news_folder = create(Builder('news folder').titled(u'News Folder'))
+
+        with freeze(datetime(2010, 3, 14, 20, 18)):
+            news1 = create(
+                Builder('news')
+                .titled(u'Usain Bolt at the Olympics')
+                .within(news_folder)
+                .having(news_date=datetime(2010, 3, 15, 12, 00),
+                        description=u'Usain Bolt wins the Olympic gold in'
+                        u' three events.\n\nThe third is for a 100-metre relay.',
+                        subjects=('Homepage', 'Sports')))
+
+            lorem = RichTextValue(self.asset('lorem1.html'))
+            block = create(Builder('sl textblock').within(news1)
+                           .with_dummy_image()
+                           .having(text=lorem))
+            utils.create_page_state(news1, block)
+
+        with freeze(datetime(2010, 5, 17, 15, 34)):
+            create(Builder('news')
+                   .titled(u'Largest Aircraft in the World')
+                   .within(news_folder)
+                   .having(news_date=datetime(2010, 5, 18, 12, 00),
+                           expires=datetime(2020, 1, 1)))
+
+        with freeze(datetime(2011, 1, 2, 3, 4)):
+            self.assert_mopage_export('01_export_news.xml', news_folder)
+
+    @browsing
+    def test_pagination(self, browser):
+        self.grant('Manager')
+        news_folder = create(Builder('news folder').titled(u'News'))
+        with freeze(datetime(2015, 10, 1)) as clock:
+            create(Builder('news').titled(u'One').within(news_folder))
+            clock.forward(days=1)
+            create(Builder('news').titled(u'Two').within(news_folder))
+            clock.forward(days=1)
+            create(Builder('news').titled(u'Three').within(news_folder))
+            clock.forward(days=1)
+            create(Builder('news').titled(u'Four').within(news_folder))
+            clock.forward(days=1)
+            create(Builder('news').titled(u'Five').within(news_folder))
+
+        browser.open(news_folder, view='mopage.news.xml?per_page=2')
+        self.assert_news_in_browser(['Five', 'Four'])
+        links = self.get_links_from_response()
+        self.assertEquals(
+            {'next': 'http://nohost/plone/news/mopage.news.xml?per_page=2&page=2',
+             'last': 'http://nohost/plone/news/mopage.news.xml?per_page=2&page=3'},
+            links)
+
+        browser.open(links['next'])
+        self.assert_news_in_browser(['Three', 'Two'])
+        links = self.get_links_from_response()
+        self.assertEquals(
+            {'first': 'http://nohost/plone/news/mopage.news.xml?per_page=2&page=1',
+             'prev': 'http://nohost/plone/news/mopage.news.xml?per_page=2&page=1',
+             'next': 'http://nohost/plone/news/mopage.news.xml?per_page=2&page=3',
+             'last': 'http://nohost/plone/news/mopage.news.xml?per_page=2&page=3'},
+            links)
+
+        browser.open(links['next'])
+        self.assert_news_in_browser(['One'])
+        links = self.get_links_from_response()
+        self.assertEquals(
+            {'first': 'http://nohost/plone/news/mopage.news.xml?per_page=2&page=1',
+             'prev': 'http://nohost/plone/news/mopage.news.xml?per_page=2&page=2'},
+            links)
+
+    @browsing
+    def test_export_all_news_on_site(self, browser):
+        self.grant('Manager')
+        create(Builder('news').titled(u'One').within(
+            create(Builder('news folder').titled(u'News Folder One'))))
+        create(Builder('news').titled(u'Two').within(
+            create(Builder('news folder').titled(u'News Folder Two'))))
+
+        browser.open(self.portal, view='mopage.news.xml')
+        self.assert_news_in_browser(['One', 'Two'])
+
+    @browsing
+    def test_title_is_cropped(self, browser):
+        self.grant('Manager')
+        create(Builder('news').titled(u'A' * 150).within(
+            create(Builder('news folder'))))
+
+        browser.open(self.portal, view='mopage.news.xml')
+        self.assert_news_in_browser(['A' * 95 + ' ...'])
+
+    @browsing
+    def test_include_root_arguments_when_submitted_as_GET_param(self, browser):
+        self.grant('Manager')
+        create(Builder('news').within(create(Builder('news folder'))))
+
+        with freeze(datetime(2016, 8, 9, 21, 45)):
+            browser.open(self.portal, view='mopage.news.xml',
+                         data={'partner': 'Partner',
+                               'partnerid': '123',
+                               'passwort': 's3c>r3t',
+                               'importid': '456',
+                               'vaterobjekt': 'xy',
+                               'unkown_key': 'should not appear'})
+
+        self.assertEquals(
+            {
+                'export_time': '2016-08-09 22:45:00',
+                'partner': 'Partner',
+                'partnerid': '123',
+                'passwort': 's3c>r3t',
+                'importid': '456',
+                'vaterobjekt': 'xy',
+            },
+            browser.css('import').first.attrib)
+
+    def assert_mopage_export(self, asset_name, export_context):
+        expected = self.asset(asset_name)
+        browser.open(export_context, view='mopage.news.xml')
+        got = browser.contents
+        # replace dynamic scale image urls for having static test results:
+        got = re.sub(r'\/@@images/[a-z0-9-]{36}.jpeg', '/image.jpg', got)
+        # remove trailing spaces:
+        got = re.sub(r' +$', '', got, flags=re.M)
+        self.maxDiff = None
+        self.assert_xml(expected, got)
+
+    def asset(self, asset_name):
+        assets = Path(__file__).joinpath('..', 'mopage_assets').abspath()
+        return assets.joinpath(asset_name).bytes()
+
+    def assert_news_in_browser(self, expected_titles):
+        got_titles = browser.css('titel').text
+        self.assertEquals(expected_titles, got_titles)
+
+    def get_links_from_response(self):
+        def parse_link(text):
+            return tuple(reversed(re.match(
+                r'^<([^>]+)>; rel="([^"]+)"', text).groups()))
+
+        return dict(map(parse_link, browser.headers.get('Link').split(',')))

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ tests_require = [
     'ftw.builder',
     'ftw.testbrowser',
     'ftw.testing>=1.11.0',
+    'path.py',
     'plone.app.testing',
     'plone.testing',
 ]

--- a/sources.cfg
+++ b/sources.cfg
@@ -5,7 +5,7 @@ extends =
 extensions += mr.developer
 
 auto-checkout =
-# Waiting for the first release of ftw.simplelayout on PyPI.
+# https://github.com/4teamwork/ftw.simplelayout/pull/369
     ftw.simplelayout
 # https://github.com/4teamwork/ftw.datepicker/pull/3
     ftw.datepicker


### PR DESCRIPTION
The "mopage.news.xml" view can be used on any context.
It returns all news contained in this context.
It is paginated to 100 items per page by default, this can be changed by submitting the `per_page` GET parameter.
When there are more pages, a `Link` response header is set, containing all necessary links (`first`, `prev`, `next`, `last`).