### PR TITLE
Implement mopage news trigger behavior.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ eggs/
 parts/
 src/
 var/
+/README.html

--- a/README.rst
+++ b/README.rst
@@ -39,8 +39,61 @@ Usage
 Create a news folder then start adding news items into the folder.
 
 
+Mopage Support
+--------------
+
+``ftw.news`` provides integration for the mopage mobile app
+(http://web.anthrazit.org/).
+
+
+Data Endpoint
+~~~~~~~~~~~~~
+
+The view ``mopage.news.xml`` returns an XML-feed with the latest news within
+the context it is called. It can becalled on any type of object.
+
+- The mopage-API expects a ``partnerid`` and a ``importid``.
+  They are incldued when submitted via GET-parameter, e.g.:
+  ``http://foo.com/news/mopage.news.xml?partnerid=123&importid=456``
+
+- The endpoint returns only 100 news by default.
+  This can be changed with the parameter ``?per_page=200``.
+
+- The endpoint returns ``Link``-headers in the response with pagination links.
+
+
+Trigger behavior
+~~~~~~~~~~~~~~~~
+
+The behavior ``ftw.news.behaviors.mopage.IPublisherMopageTrigger`` can be added
+on a news folder in order to configure automatic notification to the mopage API
+that new news are published.
+
+In order for the behavior to work properly you need an ``ftw.publisher`` setup.
+Only the receiver-side (public website) will trigger the notification.
+A configured ``collective.taskqueue`` is required for this to work.
+
+Buildout example:
+
+.. code:: ini
+
+    [instance]
+    eggs +=
+        ftw.news[mopage_publisher_receiver]
+
+    zope-conf-additional +=
+        %import collective.taskqueue
+        <taskqueue />
+        <taskqueue-server />
+
+
+Then enable the behavior for the news container type and configure the trigger
+with the newly availabe fields.
+
+
+
 Development
-===========
+==========
 
 **Python:**
 

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.2.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Implement mopage news trigger behavior. [jone]
 
 
 1.2.0 (2016-09-07)

--- a/ftw/news/behaviors/configure.zcml
+++ b/ftw/news/behaviors/configure.zcml
@@ -1,6 +1,8 @@
 <configure
     xmlns="http://namespaces.zope.org/zope"
+    xmlns:browser="http://namespaces.zope.org/browser"
     xmlns:plone="http://namespaces.plone.org/plone"
+    xmlns:zcml="http://namespaces.zope.org/zcml"
     i18n_domain="ftw.news">
 
     <include package="plone.behavior" file="meta.zcml" />
@@ -20,5 +22,36 @@
         provides=".show_on_homepage.news_listing_block.INewsOnHomepage"
         for="ftw.news.interfaces.INewsListingBlock"
         />
+
+    <plone:behavior
+        title="Mopage trigger configuration"
+        description="Provides fields for configuring a mopage trigger (ftw.publisher)."
+        provides="ftw.news.behaviors.mopage.IPublisherMopageTrigger"
+        for="ftw.news.interfaces.INewsFolder"
+        marker="ftw.news.behaviors.mopage.IPublisherMopageTriggerSupport"
+        factory="ftw.news.behaviors.mopage.PublisherMopageTrigger"
+        />
+
+    <configure zcml:condition="have ftw.news:mopage_publisher_receiver">
+
+        <subscriber
+            for="ftw.news.interfaces.INews
+                 ftw.publisher.receiver.interfaces.IAfterCreatedEvent"
+            handler=".mopage.trigger_mopage_refresh" />
+
+        <subscriber
+            for="ftw.news.interfaces.INews
+                 ftw.publisher.receiver.interfaces.IAfterUpdatedEvent"
+            handler=".mopage.trigger_mopage_refresh" />
+
+        <browser:page
+            name="taskqueue_news_trigger_mopage_refresh"
+            for="Products.CMFPlone.interfaces.siteroot.IPloneSiteRoot"
+            layer="collective.taskqueue.interfaces.ITaskQueueLayer"
+            class=".mopage.TriggerMopageRefreshTaskQueueWorker"
+            permission="zope2.View"
+            />
+
+    </configure>
 
 </configure>

--- a/ftw/news/behaviors/mopage.py
+++ b/ftw/news/behaviors/mopage.py
@@ -1,0 +1,125 @@
+from Acquisition import aq_chain
+from ftw.news import _
+from plone.app.dexterity.behaviors.metadata import DCFieldProperty
+from plone.app.dexterity.behaviors.metadata import MetadataBase
+from plone.autoform.directives import read_permission
+from plone.autoform.directives import write_permission
+from plone.directives.form import fieldset
+from plone.directives.form import IFormFieldProvider
+from plone.directives.form import Schema
+from Products.Five.browser import BrowserView
+from zope import schema
+from zope.component.hooks import getSite
+from zope.interface import alsoProvides
+from zope.interface import Interface
+import requests
+import urllib
+import urlparse
+
+
+class IPublisherMopageTrigger(Schema):
+
+    fieldset('mopage',
+             label=_(u'Mopage'),
+             fields=['mopage_enabled',
+                     'mopage_trigger_url',
+                     'mopage_data_endpoint_url'])
+
+    read_permission(mopage_enabled='ftw.news.ConfigureMopageTrigger')
+    write_permission(mopage_enabled='ftw.news.ConfigureMopageTrigger')
+    mopage_enabled = schema.Bool(
+        title=_(u'label_trigger_enabled',
+                default=u'Mopage trigger enabled'),
+        default=False,
+        required=False,
+    )
+
+    read_permission(mopage_trigger_url='ftw.news.ConfigureMopageTrigger')
+    write_permission(mopage_trigger_url='ftw.news.ConfigureMopageTrigger')
+    mopage_trigger_url = schema.URI(
+        title=_(u'label_mopage_trigger_url',
+                default=u'Mopage trigger URL'),
+        description=_(
+            u'description_mopage_trigger_url',
+            default=u'Contains the mopage URL to the trigger endpoint.'
+            u' This is only the base URL, it does not contain the endpoint URL'
+            u' from which the mopage server retrieves the news.'
+            u' Example: https://un:pw@xml.mopage.ch/infoservice/xml.php'
+        ),
+        default=None,
+        required=False,
+    )
+
+    read_permission(mopage_data_endpoint_url='ftw.news.ConfigureMopageTrigger')
+    write_permission(mopage_data_endpoint_url='ftw.news.ConfigureMopageTrigger')
+    mopage_data_endpoint_url = schema.URI(
+        title=_(u'label_mopage_data_endpoint_url',
+                default=u'Mopage data endpoint URL (Plone)'),
+        description=_(
+            u'description_mopage_data_endpoint_url',
+            default=u'The mopage data endpoint URL points to the'
+            u' "mopage.news.xml" view somewhere on the public visible '
+            u' Plone page. It must also contain the params "partnerid"'
+            u' and "importid".'
+            u' Example: https://mypage.ch/news/'
+            u'mopage.news.xml?partnerid=3&importid=6'
+        ),
+        default=None,
+        required=False,
+    )
+
+
+alsoProvides(IPublisherMopageTrigger, IFormFieldProvider)
+
+
+class IPublisherMopageTriggerSupport(Interface):
+    """Marker interface for news folders which support IPublisherMopageTrigger.
+    """
+
+
+class PublisherMopageTrigger(MetadataBase):
+    """Behavior adapter for IPublisherMopageTrigger.
+    The storage is the adapted context.
+    """
+
+    mopage_enabled = DCFieldProperty(
+        IPublisherMopageTrigger['mopage_enabled'])
+    mopage_trigger_url = DCFieldProperty(
+        IPublisherMopageTrigger['mopage_trigger_url'])
+    mopage_data_endpoint_url = DCFieldProperty(
+        IPublisherMopageTrigger['mopage_data_endpoint_url'])
+
+    def is_enabled(self):
+        return self.mopage_enabled \
+            and self.mopage_trigger_url \
+            and self.mopage_data_endpoint_url
+
+    def build_trigger_url(self):
+        if not self.is_enabled():
+            return None
+
+        parts = list(urlparse.urlparse(self.mopage_trigger_url))
+        parts[5] = ''  # drop anchor
+        parts[4] = urllib.urlencode({'url': self.mopage_data_endpoint_url})
+        return urlparse.urlunparse(parts)
+
+
+def trigger_mopage_refresh(news, event):
+    triggers = filter(None,
+                      map(lambda obj: IPublisherMopageTrigger(obj, None),
+                          aq_chain(news)))
+    if not triggers or not triggers[0].is_enabled():
+        return
+
+    from collective.taskqueue import taskqueue
+
+    trigger_url = triggers[0].build_trigger_url()
+    callback_path = '/'.join(getSite().getPhysicalPath()
+                             + ('taskqueue_news_trigger_mopage_refresh',))
+    taskqueue.add(callback_path, params={'target': trigger_url})
+
+
+class TriggerMopageRefreshTaskQueueWorker(BrowserView):
+
+    def __call__(self):
+        requests.get(self.request.form['target']).raise_for_status()

--- a/ftw/news/configure.zcml
+++ b/ftw/news/configure.zcml
@@ -1,10 +1,14 @@
 <configure
     xmlns="http://namespaces.zope.org/zope"
+    xmlns:autofeature="http://namespaces.zope.org/autofeature"
     xmlns:genericsetup="http://namespaces.zope.org/genericsetup"
     xmlns:zcml="http://namespaces.zope.org/zcml"
     xmlns:upgrade-step="http://namespaces.zope.org/ftw.upgrade"
     xmlns:i18n="http://namespaces.zope.org/i18n"
     i18n_domain="ftw.news">
+
+    <include package="ftw.autofeature" file="meta.zcml" />
+    <autofeature:extras />
 
     <include package=".behaviors" />
     <include package=".browser" />

--- a/ftw/news/lawgiver.zcml
+++ b/ftw/news/lawgiver.zcml
@@ -21,4 +21,9 @@
         permissions="ftw.news: Mark news items to show up on home page"
         />
 
+    <lawgiver:map_permissions
+        action_group="manage content settings"
+        permissions="ftw.news: Configure mopage trigger"
+        />
+
 </configure>

--- a/ftw/news/locales/de/LC_MESSAGES/ftw.news.po
+++ b/ftw/news/locales/de/LC_MESSAGES/ftw.news.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-09-01 19:02+0000\n"
+"POT-Creation-Date: 2016-09-01 19:33+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -30,17 +30,25 @@ msgstr "Archiv"
 msgid "Display the contents of a news folder."
 msgstr ""
 
-#: ./ftw/news/configure.zcml:34
+#: ./ftw/news/configure.zcml:38
 msgid "Installs a feature allowing to mark news to show on homepage."
 msgstr "Installiert ein zusätzliches Feature für die Anzeige von News-Einträgen auf der Startseite."
 
-#: ./ftw/news/behaviors/configure.zcml:15
+#: ./ftw/news/behaviors/configure.zcml:17
 msgid "Mark news items to show up on the homepage"
 msgstr "News-Einträge für Anzeige auf Startseite markieren"
 
-#: ./ftw/news/behaviors/configure.zcml:22
+#: ./ftw/news/behaviors/configure.zcml:24
 msgid "Mark news listing block to render news on homepage"
 msgstr ""
+
+#: ./ftw/news/behaviors/mopage.py:23
+msgid "Mopage"
+msgstr "Mopage"
+
+#: ./ftw/news/behaviors/configure.zcml:33
+msgid "Mopage trigger configuration"
+msgstr "Mopage auslöser konfiguration"
 
 #: ./ftw/news/profiles/default/types/ftw.news.News.xml
 msgid "News"
@@ -54,11 +62,11 @@ msgstr "News-Verzeichnis"
 msgid "News listing"
 msgstr "News-Auflistung"
 
-#: ./ftw/news/behaviors/configure.zcml:22
+#: ./ftw/news/behaviors/configure.zcml:24
 msgid "News listing block on homepage"
 msgstr ""
 
-#: ./ftw/news/behaviors/configure.zcml:15
+#: ./ftw/news/behaviors/configure.zcml:17
 msgid "News on homepage"
 msgstr ""
 
@@ -69,6 +77,10 @@ msgstr "News-Auflistung"
 #: ./ftw/news/browser/templates/news_listing_block.pt:13
 msgid "No content available"
 msgstr "Kein Inhalt verfügbar"
+
+#: ./ftw/news/behaviors/configure.zcml:33
+msgid "Provides fields for configuring a mopage trigger (ftw.publisher)."
+msgstr "Felder für die Konfiguration des Mopage Auslösers."
 
 #: ./ftw/news/browser/templates/news_listing.pt:9
 msgid "RSS"
@@ -82,6 +94,16 @@ msgstr "RSS abonnieren"
 msgid "The news listing block renders a configurable list of news entries."
 msgstr "Der Newsauflistungsblock zeigt eine konfigurierbare Liste von Nachrichten-Meldungen an."
 
+#. Default: "The mopage data endpoint URL points to the \"mopage.news.xml\" view somewhere on the public visible  Plone page. It must also contain the params \"partnerid\" and \"importid\". Example: https://mypage.ch/news/mopage.news.xml?partnerid=3&importid=6"
+#: ./ftw/news/behaviors/mopage.py:58
+msgid "description_mopage_data_endpoint_url"
+msgstr "Die Mopage Endpoint-URL zeigt auf die \"mopage.news.xml\"-Ansicht eines News-Ordners auf Plone. Die URL muss die Parameter \"partnerid\" und \"importid\" enthalten. Die URL muss vollständig sein und auf die öffentliche Seite zeigen. Beispiel: https://mypage.ch/news/mopage.news.xml?partnerid=3&importid=6"
+
+#. Default: "Contains the mopage URL to the trigger endpoint. This is only the base URL, it does not contain the endpoint URL from which the mopage server retrieves the news. Example: https://un:pw@xml.mopage.ch/infoservice/xml.php"
+#: ./ftw/news/behaviors/mopage.py:42
+msgid "description_mopage_trigger_url"
+msgstr "Die Trigger-URL zeigt auf die Mopage-API. Sie enthält kein \"?url\"-Parameter, dieser wird automatisch angefügt. Beispiel: https://un:pw@xml.mopage.ch/infoservice/xml.php"
+
 #. Default: "This custom label will not be translated."
 #: ./ftw/news/contents/news_listing_block.py:22
 msgid "description_more_news_link_label"
@@ -92,11 +114,11 @@ msgstr "Dieses Label wird nicht übersetzt."
 msgid "description_show_on_homepage"
 msgstr "Ermöglicht die Anzeige dieses Eintrages auf der Startseite."
 
-#: ./ftw/news/configure.zcml:26
+#: ./ftw/news/configure.zcml:30
 msgid "ftw.news"
-msgstr ""
+msgstr "ftw.news"
 
-#: ./ftw/news/configure.zcml:34
+#: ./ftw/news/configure.zcml:38
 msgid "ftw.news (show on homepage feature)"
 msgstr ""
 
@@ -104,6 +126,16 @@ msgstr ""
 #: ./ftw/news/browser/news_listing.py:94
 msgid "label_feed_desc"
 msgstr "${title} - News Feed"
+
+#. Default: "Mopage data endpoint URL (Plone)"
+#: ./ftw/news/behaviors/mopage.py:56
+msgid "label_mopage_data_endpoint_url"
+msgstr "Mopage: URL zu Daten-Endpoint"
+
+#. Default: "Mopage trigger URL"
+#: ./ftw/news/behaviors/mopage.py:40
+msgid "label_mopage_trigger_url"
+msgstr "Mopage Trigger URL"
 
 #. Default: "Label for the \"more news\" link"
 #: ./ftw/news/contents/news_listing_block.py:20
@@ -114,6 +146,11 @@ msgstr "Label für den Link \"Weitere Einträge\""
 #: ./ftw/news/behaviors/show_on_homepage/news.py:17
 msgid "label_show_on_homepage"
 msgstr "Auf Startseite anzeigen"
+
+#. Default: "Mopage trigger enabled"
+#: ./ftw/news/behaviors/mopage.py:31
+msgid "label_trigger_enabled"
+msgstr "Mopage Trigger aktiviert"
 
 msgid "mark news items to show up on home page"
 msgstr "News-Einträge für Anzeige auf Startseite markieren"
@@ -315,4 +352,3 @@ msgstr "Keine Einträge vorhanden."
 #: ./ftw/news/portlets/templates/news_portlet.pt:43
 msgid "rss_link_title"
 msgstr "RSS abonnieren"
-

--- a/ftw/news/locales/ftw.news.pot
+++ b/ftw/news/locales/ftw.news.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-09-01 19:02+0000\n"
+"POT-Creation-Date: 2016-09-01 19:33+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -30,16 +30,24 @@ msgstr ""
 msgid "Display the contents of a news folder."
 msgstr ""
 
-#: ./ftw/news/configure.zcml:34
+#: ./ftw/news/configure.zcml:38
 msgid "Installs a feature allowing to mark news to show on homepage."
 msgstr ""
 
-#: ./ftw/news/behaviors/configure.zcml:15
+#: ./ftw/news/behaviors/configure.zcml:17
 msgid "Mark news items to show up on the homepage"
 msgstr ""
 
-#: ./ftw/news/behaviors/configure.zcml:22
+#: ./ftw/news/behaviors/configure.zcml:24
 msgid "Mark news listing block to render news on homepage"
+msgstr ""
+
+#: ./ftw/news/behaviors/mopage.py:23
+msgid "Mopage"
+msgstr ""
+
+#: ./ftw/news/behaviors/configure.zcml:33
+msgid "Mopage trigger configuration"
 msgstr ""
 
 #: ./ftw/news/profiles/default/types/ftw.news.News.xml
@@ -54,11 +62,11 @@ msgstr ""
 msgid "News listing"
 msgstr ""
 
-#: ./ftw/news/behaviors/configure.zcml:22
+#: ./ftw/news/behaviors/configure.zcml:24
 msgid "News listing block on homepage"
 msgstr ""
 
-#: ./ftw/news/behaviors/configure.zcml:15
+#: ./ftw/news/behaviors/configure.zcml:17
 msgid "News on homepage"
 msgstr ""
 
@@ -68,6 +76,10 @@ msgstr ""
 
 #: ./ftw/news/browser/templates/news_listing_block.pt:13
 msgid "No content available"
+msgstr ""
+
+#: ./ftw/news/behaviors/configure.zcml:33
+msgid "Provides fields for configuring a mopage trigger (ftw.publisher)."
 msgstr ""
 
 #: ./ftw/news/browser/templates/news_listing.pt:9
@@ -82,6 +94,16 @@ msgstr ""
 msgid "The news listing block renders a configurable list of news entries."
 msgstr ""
 
+#. Default: "The mopage data endpoint URL points to the \"mopage.news.xml\" view somewhere on the public visible  Plone page. It must also contain the params \"partnerid\" and \"importid\". Example: https://mypage.ch/news/mopage.news.xml?partnerid=3&importid=6"
+#: ./ftw/news/behaviors/mopage.py:58
+msgid "description_mopage_data_endpoint_url"
+msgstr ""
+
+#. Default: "Contains the mopage URL to the trigger endpoint. This is only the base URL, it does not contain the endpoint URL from which the mopage server retrieves the news. Example: https://un:pw@xml.mopage.ch/infoservice/xml.php"
+#: ./ftw/news/behaviors/mopage.py:42
+msgid "description_mopage_trigger_url"
+msgstr ""
+
 #. Default: "This custom label will not be translated."
 #: ./ftw/news/contents/news_listing_block.py:22
 msgid "description_more_news_link_label"
@@ -92,17 +114,27 @@ msgstr ""
 msgid "description_show_on_homepage"
 msgstr ""
 
-#: ./ftw/news/configure.zcml:26
+#: ./ftw/news/configure.zcml:30
 msgid "ftw.news"
 msgstr ""
 
-#: ./ftw/news/configure.zcml:34
+#: ./ftw/news/configure.zcml:38
 msgid "ftw.news (show on homepage feature)"
 msgstr ""
 
 #. Default: "${title} - News Feed"
 #: ./ftw/news/browser/news_listing.py:94
 msgid "label_feed_desc"
+msgstr ""
+
+#. Default: "Mopage data endpoint URL (Plone)"
+#: ./ftw/news/behaviors/mopage.py:56
+msgid "label_mopage_data_endpoint_url"
+msgstr ""
+
+#. Default: "Mopage trigger URL"
+#: ./ftw/news/behaviors/mopage.py:40
+msgid "label_mopage_trigger_url"
 msgstr ""
 
 #. Default: "Label for the \"more news\" link"
@@ -113,6 +145,11 @@ msgstr ""
 #. Default: "Show on home page"
 #: ./ftw/news/behaviors/show_on_homepage/news.py:17
 msgid "label_show_on_homepage"
+msgstr ""
+
+#. Default: "Mopage trigger enabled"
+#: ./ftw/news/behaviors/mopage.py:31
+msgid "label_trigger_enabled"
 msgstr ""
 
 msgid "mark news items to show up on home page"

--- a/ftw/news/permissions.zcml
+++ b/ftw/news/permissions.zcml
@@ -22,4 +22,9 @@
         title="ftw.news: Mark news items to show up on home page"
         />
 
+    <permission
+        id="ftw.news.ConfigureMopageTrigger"
+        title="ftw.news: Configure mopage trigger"
+        />
+
 </configure>

--- a/ftw/news/profiles/default/rolemap.xml
+++ b/ftw/news/profiles/default/rolemap.xml
@@ -20,5 +20,10 @@
             <role name="Contributor"/>
         </permission>
 
+        <permission name="ftw.news: Configure mopage trigger" acquire="False">
+            <role name="Manager"/>
+            <role name="Site Administrator"/>
+        </permission>
+
     </permissions>
 </rolemap>

--- a/ftw/news/tests/test_mopage_trigger.py
+++ b/ftw/news/tests/test_mopage_trigger.py
@@ -1,0 +1,121 @@
+from collective.taskqueue.testing import runAsyncTest
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.news.behaviors.mopage import IPublisherMopageTrigger
+from ftw.news.testing import MOPAGE_TRIGGER_FUNCTIONAL
+from ftw.news.tests import FunctionalTestCase
+from ftw.publisher.receiver.events import AfterCreatedEvent
+from ftw.publisher.receiver.events import AfterUpdatedEvent
+from ftw.testbrowser import browsing
+from ftw.testbrowser.pages import factoriesmenu
+from ftw.testbrowser.pages import statusmessages
+from persistent.list import PersistentList
+from Products.CMFCore.utils import getToolByName
+from Products.Five.browser import BrowserView
+from zope.annotation.interfaces import IAnnotations
+from zope.event import notify
+import transaction
+import urlparse
+
+
+def get_stub_log(portal):
+    annotations = IAnnotations(portal)
+    key = 'ftw.news-mopage-stub-log'
+    if key not in annotations:
+        annotations[key] = PersistentList()
+    return annotations[key]
+
+
+class MopageAPIStub(BrowserView):
+
+    def __call__(self):
+        log = get_stub_log(self.context)
+        log.append(self.request.form)
+        return 'OK'
+
+
+class TestMopageTrigger(FunctionalTestCase):
+    layer = MOPAGE_TRIGGER_FUNCTIONAL
+
+    def setUp(self):
+        super(TestMopageTrigger, self).setUp()
+
+        portal_types = getToolByName(self.portal, 'portal_types')
+        portal_types['ftw.news.NewsFolder'].behaviors += (
+            'ftw.news.behaviors.mopage.IPublisherMopageTrigger',
+        )
+        transaction.commit()
+
+    @browsing
+    def test_configure_trigger_on_news_folder(self, browser):
+        self.grant('Manager')
+        browser.login().open()
+        factoriesmenu.add('News Folder')
+        browser.fill(
+            {'Title': 'News Folder',
+             'Mopage trigger enabled': True,
+             'Mopage trigger URL': (
+                 'https://un:pw@xml.mopage.ch/infoservice/xml.php'),
+             'Mopage data endpoint URL (Plone)': (
+                 'http://nohost/plone/news-folder/mopage.news.xml'
+                 '?partnerid=123&imported=456')}).save()
+
+        statusmessages.assert_no_error_messages()
+
+        mopage_trigger = IPublisherMopageTrigger(browser.context)
+        self.assertTrue(mopage_trigger.is_enabled())
+
+        trigger_url = mopage_trigger.build_trigger_url()
+        self.assertEquals('https://un:pw@xml.mopage.ch/infoservice/xml.php'
+                          '?url=http%3A%2F%2Fnohost%2Fplone%2Fnews-folder'
+                          '%2Fmopage.news.xml%3Fpartnerid%3D123%26imported%3D456',
+                          trigger_url)
+
+        params =  urlparse.parse_qs(urlparse.urlparse(trigger_url)[4])['url']
+        self.assertEquals(['http://nohost/plone/news-folder/'
+                           'mopage.news.xml?partnerid=123&imported=456'],
+                          params)
+
+    def test_trigger_notified_when_news_created(self):
+        trigger_url = self.portal.portal_url() + '/mopage-stub'
+        endpoint_url = (self.portal.portal_url() + '/news-folder/mopage.news.xml' +
+                        '?partnerid=213&importid=456')
+
+        folder = create(Builder('news folder')
+                        .titled(u'News Folder')
+                        .having(mopage_enabled=True,
+                                mopage_trigger_url=trigger_url,
+                                mopage_data_endpoint_url=endpoint_url))
+
+        news = create(Builder('news').titled(u'The News').within(folder))
+        self.assertEquals([], get_stub_log(self.portal))
+
+        notify(AfterCreatedEvent(news))
+        transaction.commit()
+        runAsyncTest(lambda: None)
+        transaction.begin()
+        self.assertEquals(
+            [{'url': endpoint_url}],
+            get_stub_log(self.portal))
+
+    def test_trigger_notified_when_news_updated(self):
+        trigger_url = self.portal.portal_url() + '/mopage-stub'
+        endpoint_url = (self.portal.portal_url() + '/news-folder/mopage.news.xml' +
+                        '?partnerid=999&importid=888')
+
+        folder = create(Builder('news folder')
+                        .titled(u'News Folder')
+                        .having(mopage_enabled=True,
+                                mopage_trigger_url=trigger_url,
+                                mopage_data_endpoint_url=endpoint_url))
+
+        news = create(Builder('news').titled(u'The News').within(folder))
+        self.assertEquals([], get_stub_log(self.portal))
+
+        notify(AfterUpdatedEvent(news))
+        transaction.commit()
+        runAsyncTest(lambda: None)
+        transaction.begin()
+        self.assertEquals(
+            [{'url': endpoint_url}],
+            get_stub_log(self.portal))

--- a/ftw/news/upgrades/20160901175856_update_rolemap_with_new_permission/rolemap.xml
+++ b/ftw/news/upgrades/20160901175856_update_rolemap_with_new_permission/rolemap.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+<rolemap>
+    <permissions>
+
+        <permission name="ftw.news: Configure mopage trigger" acquire="False">
+            <role name="Manager"/>
+            <role name="Site Administrator"/>
+        </permission>
+
+    </permissions>
+</rolemap>

--- a/ftw/news/upgrades/20160901175856_update_rolemap_with_new_permission/upgrade.py
+++ b/ftw/news/upgrades/20160901175856_update_rolemap_with_new_permission/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class UpdateRolemapWithNewPermission(UpgradeStep):
+    """Update rolemap with new permission.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()

--- a/setup.py
+++ b/setup.py
@@ -12,11 +12,22 @@ tests_require = [
     'path.py',
     'plone.app.testing',
     'plone.testing',
+    'ftw.news[mopage_publisher_receiver]',
 ]
 
 extras_require = {
     'tests': tests_require,
     'test': tests_require,
+
+    # The mopage_publisher_receiver should be installed on a ftw.publisher
+    # receiver installation in order to enable the mopage trigger function.
+    # It should *NOT* be installed on ftw.pubsliher.sender site, since
+    # the trigger will then be triggered too early.
+    'mopage_publisher_receiver': [
+        'collective.taskqueue',
+        'ftw.publisher.receiver',
+        'requests',
+    ],
 }
 
 setup(
@@ -51,6 +62,7 @@ setup(
 
     install_requires=[
         'Plone',
+        'ftw.autofeature',
         'ftw.datepicker',
         'ftw.simplelayout [contenttypes]',
         'plone.api',


### PR DESCRIPTION
The news trigger behavior for the news container provides configuration
fields for setting up automatic notification to the mopage API whenever
a news page is published with ftw.publisher (receiver side).

This requires an ftw.publisher setup as well as a configured
collective.taskqueue.
The notification will be triggered when the ftw.publisher.receiver has
received a news update.