### PR TITLE
Fix plone first heading of news listing view on various portal types.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 1.2.0 (unreleased)
 ------------------
 
+- Fix plone first heading of news listing view on various portal
+  types. [mbaechtold]
+
 - Implement "mopage.news.xml" API browser view. [jone]
 
 - Enable IExcludeFromNavigation behavior for news folders. [jone]

--- a/ftw/news/browser/news_listing.py
+++ b/ftw/news/browser/news_listing.py
@@ -3,8 +3,8 @@ from Acquisition import aq_parent
 from DateTime import DateTime
 from ftw.news import _
 from ftw.news import utils
-from ftw.news.interfaces import INewsFolder
 from ftw.news.interfaces import INewsListingView
+from ftw.simplelayout.contenttypes.contents.interfaces import IContentPage
 from plone.portlets.interfaces import IPortletAssignmentMapping
 from plone.portlets.interfaces import IPortletManager
 from plone.portlets.interfaces import IPortletRenderer
@@ -81,9 +81,12 @@ class NewsListing(BrowserView):
     @property
     def title(self):
         title = self.context.Title()
-        if INewsFolder.providedBy(self.context):
-            return title
-        return self.context.Title() + ' - News'
+
+        appendix = 'News'
+        if IContentPage.providedBy(self.context) and title != appendix:
+            return title + ' - ' + appendix
+
+        return title
 
     @property
     def link(self):

--- a/ftw/news/contents/news_listing_block.py
+++ b/ftw/news/contents/news_listing_block.py
@@ -32,3 +32,6 @@ alsoProvides(INewsListingBlockSchema, IFormFieldProvider)
 
 class NewsListingBlock(Container):
     implements(INewsListingBlock)
+
+    def Title(self):
+        return self.news_listing_config_title

--- a/ftw/news/testing.py
+++ b/ftw/news/testing.py
@@ -28,6 +28,7 @@ class FtwNewsLayer(PloneSandboxLayer):
     def setUpPloneSite(self, portal):
         # Install into Plone site using portal_setup
         applyProfile(portal, 'ftw.news:default')
+        applyProfile(portal, 'ftw.subsite:default')
 
 FTW_NEWS_FIXTURE = FtwNewsLayer()
 

--- a/ftw/news/tests/builders.py
+++ b/ftw/news/tests/builders.py
@@ -1,6 +1,7 @@
 from ftw.builder import builder_registry
 from ftw.builder.dexterity import DexterityBuilder
 from ftw.simplelayout.tests import builders
+from ftw.subsite.tests import builders
 
 
 class NewsFolderBuilder(DexterityBuilder):
@@ -19,9 +20,7 @@ class NewsListingBlockBuilder(DexterityBuilder):
     portal_type = 'ftw.news.NewsListingBlock'
 
     def titled(self, title):
-        self.arguments['title'] = self.arguments['news_listing_config_title'] \
-            = title
+        self.arguments['news_listing_config_title'] = title
         return self
-
 
 builder_registry.register('news listing block', NewsListingBlockBuilder)

--- a/ftw/news/tests/test_news_listing.py
+++ b/ftw/news/tests/test_news_listing.py
@@ -85,29 +85,27 @@ class TestNewsListing(FunctionalTestCase):
             'allowAnonymousViewAbout is True.')
 
     @browsing
-    def test_news_listing_inside_contentpage(self, browser):
-        page = create(Builder('sl content page').titled(u'Content page'))
-        news_folder = create(Builder(u'news folder')
-                             .titled(u'A News Folder')
-                             .within(page))
-
+    def test_first_heading_of_news_listing_on_contentpage(self, browser):
+        """
+        This test makes sure that the first heading is correct when the
+        view "@@news_listing" is called on a content page.
+        "News" will be appended to the title of the content page.
+        """
+        page = create(Builder('sl content page')
+                      .titled(u'Content page'))
         browser.login().visit(page, view='@@news_listing')
-        self.assertEquals('Content page - News', plone.first_heading())
-
-        browser.visit(news_folder)
-        self.assertEquals(u'A News Folder', plone.first_heading())
+        self.assertEquals(u'Content page - News', plone.first_heading())
 
     @browsing
-    def test_news_listing_title(self, browser):
+    def test_first_heading_of_news_listing_on_news_folder(self, browser):
         """
-        This test makes sure that the news listing view renders the
-        title of the portlet, not the generic title.
+        This test makes sure that the first heading is correct when the
+        view "@@news_listing" is called on a news folder.
         """
-        browser.login().visit(self.news_folder, view='news_listing')
-        self.assertEquals(
-            ['A News Folder'],
-            browser.css('h1.documentFirstHeading').text
-        )
+        news_folder = create(Builder(u'news folder')
+                             .titled(u'A News Folder'))
+        browser.visit(news_folder)
+        self.assertEquals(u'A News Folder', plone.first_heading())
 
     @browsing
     def test_news_listing_no_description(self, browser):
@@ -149,6 +147,7 @@ class TestNewsListing(FunctionalTestCase):
                       .having(news_date=datetime.now()))
         news.Creator = userid
         self.assertEquals(userid, get_creator(news))
+
 
 class TestNewsListingFormat(FunctionalTestCase):
 

--- a/ftw/news/tests/test_news_listing_block.py
+++ b/ftw/news/tests/test_news_listing_block.py
@@ -7,6 +7,7 @@ from ftw.news.tests import utils
 from ftw.news.tests.utils import set_allow_anonymous_view_about
 from ftw.testbrowser import browsing
 from ftw.testbrowser.pages import factoriesmenu
+from ftw.testbrowser.pages import plone
 from plone.app.testing import applyProfile
 
 
@@ -296,3 +297,31 @@ class TestNewsListingBlockContentType(FunctionalTestCase):
             "The news listing block on the Plone Site must only render "
             "news items having been marked to be shown on the homepage."
         )
+
+    @browsing
+    def test_first_heading_of_news_listing_on_news_listing_block_within_root(self, browser):
+        """
+        This test makes sure that the first heading is correct when the
+        view "@@news_listing" is called on a news listing block which has
+        been added on the subsite view of the Plone site (root).
+        """
+        block = create(Builder('news listing block')
+                       .titled(u'Awesome News'))
+
+        browser.login().visit(block, view='@@news_listing')
+        self.assertEquals(u'Awesome News', plone.first_heading())
+
+    @browsing
+    def test_first_heading_of_news_listing_on_news_listing_block_within_subsite(self, browser):
+        """
+        This test makes sure that the first heading is correct when the
+        view "@@news_listing" is called on a news listing block which has
+        been added on the subsite view of a subsite.
+        """
+        subsite = create(Builder('subsite').titled(u'My Subsite'))
+        block = create(Builder('news listing block')
+                       .titled(u'Awesome News')
+                       .within(subsite))
+
+        browser.login().visit(block, view='@@news_listing')
+        self.assertEquals(u'Awesome News', plone.first_heading())

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,7 @@ maintainer = 'Mathias Leimgruber'
 
 tests_require = [
     'ftw.builder',
+    'ftw.subsite',
     'ftw.testbrowser',
     'ftw.testing>=1.11.0',
     'path.py',


### PR DESCRIPTION
- `@@news_listing` called on content page: the title of the content page is rendered with a special appendix (`Title of the content page - News`).
- `@@news_listing` called on news listing block: the special listing title of the listing block (named `news_listing_config_title`) is rendered.
- `@@news_listing` called on other portal types (including news listing folder): the title of the context is rendered