### PR TITLE
remove superfluous comments from FTI definitions.

### DIFF
--- a/ftw/news/profiles/default/types/ftw.news.News.xml
+++ b/ftw/news/profiles/default/types/ftw.news.News.xml
@@ -4,7 +4,6 @@
         xmlns:i18n="http://xml.zope.org/namespaces/i18n"
         i18n:domain="ftw.news" >
 
-    <!-- Basic metadata -->
     <property name="title" i18n:translate="">News</property>
     <property name="description" i18n:translate=""></property>
     <property name="icon_expr"></property>
@@ -19,16 +18,10 @@
         <element value="ftw.simplelayout.GalleryBlock" />
     </property>
 
-    <!-- schema interface -->
     <property name="schema">ftw.news.contents.news.INewsSchema</property>
-
-    <!-- class used for content items -->
     <property name="klass">ftw.news.contents.news.News</property>
-
-    <!-- add permission -->
     <property name="add_permission">ftw.news.AddNews</property>
 
-    <!-- enabled behaviors -->
     <property name="behaviors">
         <element value="ftw.simplelayout.interfaces.ISimplelayout" />
         <element value="plone.app.dexterity.behaviors.metadata.IBasic"/>
@@ -39,20 +32,17 @@
         <element value="plone.app.dexterity.behaviors.metadata.IPublication" />
     </property>
 
-    <!-- View information -->
     <property name="default_view">@@simplelayout-view</property>
     <property name="default_view_fallback">False</property>
     <property name="view_methods">
         <element value="@@simplelayout-view"/>
     </property>
 
-    <!-- Method aliases -->
     <alias from="(Default)" to="(dynamic view)"/>
     <alias from="edit" to="@@edit"/>
     <alias from="sharing" to="@@sharing"/>
     <alias from="view" to="(selected layout)"/>
 
-    <!-- Actions -->
     <action
         action_id="view"
         title="View"

--- a/ftw/news/profiles/default/types/ftw.news.NewsFolder.xml
+++ b/ftw/news/profiles/default/types/ftw.news.NewsFolder.xml
@@ -4,7 +4,6 @@
         xmlns:i18n="http://xml.zope.org/namespaces/i18n"
         i18n:domain="ftw.news" >
 
-    <!-- Basic metadata -->
     <property name="title" i18n:translate="">News Folder</property>
     <property name="description" i18n:translate="">A container for news items.</property>
     <property name="icon_expr"></property>
@@ -15,16 +14,10 @@
         <element value="ftw.news.News"></element>
     </property>
 
-    <!-- schema interface -->
     <property name="schema">ftw.news.contents.news_folder.INewsFolderSchema</property>
-
-    <!-- class used for content items -->
     <property name="klass">ftw.news.contents.news_folder.NewsFolder</property>
-
-    <!-- add permission -->
     <property name="add_permission">ftw.news.AddNewsFolder</property>
 
-    <!-- enabled behaviors -->
     <property name="behaviors">
         <element value="plone.app.dexterity.behaviors.metadata.IBasic"/>
         <element value="plone.app.content.interfaces.INameFromTitle" />
@@ -32,7 +25,6 @@
         <element value="plone.app.dexterity.behaviors.exclfromnav.IExcludeFromNavigation" />
     </property>
 
-    <!-- View information -->
     <property name="immediate_view">news_listing</property>
     <property name="default_view">news_listing</property>
     <property name="view_methods">
@@ -40,7 +32,6 @@
     </property>
     <property name="default_view_fallback">False</property>
 
-    <!-- Method aliases -->
     <alias from="(Default)" to="(dynamic view)" />
     <alias from="view" to="(selected layout)" />
     <alias from="edit" to="@@edit" />

--- a/ftw/news/profiles/default/types/ftw.news.NewsListingBlock.xml
+++ b/ftw/news/profiles/default/types/ftw.news.NewsListingBlock.xml
@@ -4,7 +4,6 @@
         xmlns:i18n="http://xml.zope.org/namespaces/i18n"
         i18n:domain="ftw.news" >
 
-    <!-- Basic metadata -->
     <property name="title" i18n:translate="">NewsListingBlock</property>
     <property name="description" i18n:translate="">The news listing block renders a configurable list of news entries.</property>
     <property name="icon_expr"></property>
@@ -13,30 +12,22 @@
     <property name="filter_content_types">True</property>
     <property name="allowed_content_types"></property>
 
-    <!-- schema interface -->
     <property name="schema">ftw.news.contents.news_listing_block.INewsListingBlockSchema</property>
-
-    <!-- class used for content items -->
     <property name="klass">ftw.news.contents.news_listing_block.NewsListingBlock</property>
-
-    <!-- add permission -->
     <property name="add_permission">ftw.news.AddNewsListingBlock</property>
 
-    <!-- enabled behaviors -->
     <property name="behaviors">
         <element value="plone.app.content.interfaces.INameFromTitle" />
         <element value="ftw.simplelayout.interfaces.ISimplelayoutBlock" />
         <element value="plone.app.referenceablebehavior.referenceable.IReferenceable"/>
     </property>
 
-   <!-- View information -->
     <property name="default_view">block_view</property>
     <property name="default_view_fallback">False</property>
     <property name="view_methods">
         <element value="block_view"/>
     </property>
 
-    <!-- Method aliases -->
     <alias from="(Default)" to="(dynamic view)"/>
     <alias from="edit" to="@@edit"/>
     <alias from="sharing" to="@@sharing"/>


### PR DESCRIPTION
The comments in the FTI definitions are distracting at most.
They are superfluous because the same information is contained in the XML tag below.