### PR TITLE
Use simplelayout for news folder

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -39,6 +39,20 @@ Usage
 Create a news folder then start adding news items into the folder.
 
 
+News listing and archive portlet
+--------------------------------
+
+By default, news folders support simplelayout and a news listing block is
+added to the news folder when the folder is created.
+There is also a news archive portlet, which works with the ``news_listing``
+view, but it does only appear on the news folder when the news folder default
+layout is switched to ``news_listing`` or on views such as the archive view
+of the news listing block.
+The portlet does not appear on the simplalyout view (standard view) of news
+folders because they may have no or many news listing blocks, which would then
+be confusing.
+
+
 Mopage Support
 --------------
 

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.3.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Use simplelayout by default for news folders. [jone]
 
 
 1.3.1 (2016-09-19)

--- a/ftw/news/configure.zcml
+++ b/ftw/news/configure.zcml
@@ -47,6 +47,12 @@
         name="ftw.news.vocabulary.subjects"
         />
 
+    <subscriber
+        for="ftw.news.interfaces.INewsFolder
+             zope.lifecycleevent.interfaces.IObjectAddedEvent"
+        handler="ftw.news.contents.news_folder.create_news_listing_block"
+        />
+
     <adapter factory=".indexer.news_start_date" name="start"/>
 
 </configure>

--- a/ftw/news/contents/news_folder.py
+++ b/ftw/news/contents/news_folder.py
@@ -1,7 +1,11 @@
+from ftw.news import _
 from ftw.news.interfaces import INewsFolder
+from plone import api
 from plone.autoform.interfaces import IFormFieldProvider
 from plone.dexterity.content import Container
 from plone.directives import form
+from zope.component.hooks import getSite
+from zope.i18n import translate
 from zope.interface import alsoProvides
 from zope.interface import implements
 
@@ -14,3 +18,28 @@ alsoProvides(INewsFolderSchema, IFormFieldProvider)
 
 class NewsFolder(Container):
     implements(INewsFolder)
+
+
+def create_news_listing_block(news_folder, event=None):
+    """
+    This methods creates a news listing block inside the given news folder
+    and is used as a handler for a subscriber listening to the creation
+    of news folders.
+    """
+
+    title = translate(
+        _(u'title_default_newslisting_block', u'News'),
+        context=getSite().REQUEST
+    )
+
+    api.content.create(
+        news_folder,
+        'ftw.news.NewsListingBlock',
+        title=title,
+        news_listing_config_title=title,
+        current_context=True,
+        subjects=[],
+        show_title=False,
+        filter_by_path=[],
+        show_more_news_link=True,
+    )

--- a/ftw/news/locales/de/LC_MESSAGES/ftw.news.po
+++ b/ftw/news/locales/de/LC_MESSAGES/ftw.news.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-09-01 19:33+0000\n"
+"POT-Creation-Date: 2016-09-19 12:57+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -95,7 +95,7 @@ msgid "The news listing block renders a configurable list of news entries."
 msgstr "Der Newsauflistungsblock zeigt eine konfigurierbare Liste von Nachrichten-Meldungen an."
 
 #. Default: "The mopage data endpoint URL points to the \"mopage.news.xml\" view somewhere on the public visible  Plone page. It must also contain the params \"partnerid\" and \"importid\". Example: https://mypage.ch/news/mopage.news.xml?partnerid=3&importid=6"
-#: ./ftw/news/behaviors/mopage.py:58
+#: ./ftw/news/behaviors/mopage.py:59
 msgid "description_mopage_data_endpoint_url"
 msgstr "Die Mopage Endpoint-URL zeigt auf die \"mopage.news.xml\"-Ansicht eines News-Ordners auf Plone. Die URL muss die Parameter \"partnerid\" und \"importid\" enthalten. Die URL muss vollständig sein und auf die öffentliche Seite zeigen. Beispiel: https://mypage.ch/news/mopage.news.xml?partnerid=3&importid=6"
 
@@ -123,12 +123,12 @@ msgid "ftw.news (show on homepage feature)"
 msgstr ""
 
 #. Default: "${title} - News Feed"
-#: ./ftw/news/browser/news_listing.py:94
+#: ./ftw/news/browser/news_listing.py:97
 msgid "label_feed_desc"
 msgstr "${title} - News Feed"
 
 #. Default: "Mopage data endpoint URL (Plone)"
-#: ./ftw/news/behaviors/mopage.py:56
+#: ./ftw/news/behaviors/mopage.py:57
 msgid "label_mopage_data_endpoint_url"
 msgstr "Mopage: URL zu Daten-Endpoint"
 
@@ -156,7 +156,7 @@ msgid "mark news items to show up on home page"
 msgstr "News-Einträge für Anzeige auf Startseite markieren"
 
 #. Default: "More News"
-#: ./ftw/news/browser/news_listing_block.py:33
+#: ./ftw/news/browser/news_listing_block.py:35
 #: ./ftw/news/browser/templates/news_listing_block.pt:48
 #: ./ftw/news/portlets/templates/news_portlet.pt:37
 msgid "more_news_link_label"
@@ -352,3 +352,8 @@ msgstr "Keine Einträge vorhanden."
 #: ./ftw/news/portlets/templates/news_portlet.pt:43
 msgid "rss_link_title"
 msgstr "RSS abonnieren"
+
+#. Default: "News"
+#: ./ftw/news/contents/news_folder.py:33
+msgid "title_default_newslisting_block"
+msgstr "News"

--- a/ftw/news/locales/ftw.news.pot
+++ b/ftw/news/locales/ftw.news.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-09-01 19:33+0000\n"
+"POT-Creation-Date: 2016-09-19 12:57+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -95,7 +95,7 @@ msgid "The news listing block renders a configurable list of news entries."
 msgstr ""
 
 #. Default: "The mopage data endpoint URL points to the \"mopage.news.xml\" view somewhere on the public visible  Plone page. It must also contain the params \"partnerid\" and \"importid\". Example: https://mypage.ch/news/mopage.news.xml?partnerid=3&importid=6"
-#: ./ftw/news/behaviors/mopage.py:58
+#: ./ftw/news/behaviors/mopage.py:59
 msgid "description_mopage_data_endpoint_url"
 msgstr ""
 
@@ -123,12 +123,12 @@ msgid "ftw.news (show on homepage feature)"
 msgstr ""
 
 #. Default: "${title} - News Feed"
-#: ./ftw/news/browser/news_listing.py:94
+#: ./ftw/news/browser/news_listing.py:97
 msgid "label_feed_desc"
 msgstr ""
 
 #. Default: "Mopage data endpoint URL (Plone)"
-#: ./ftw/news/behaviors/mopage.py:56
+#: ./ftw/news/behaviors/mopage.py:57
 msgid "label_mopage_data_endpoint_url"
 msgstr ""
 
@@ -156,7 +156,7 @@ msgid "mark news items to show up on home page"
 msgstr ""
 
 #. Default: "More News"
-#: ./ftw/news/browser/news_listing_block.py:33
+#: ./ftw/news/browser/news_listing_block.py:35
 #: ./ftw/news/browser/templates/news_listing_block.pt:48
 #: ./ftw/news/portlets/templates/news_portlet.pt:37
 msgid "more_news_link_label"
@@ -351,5 +351,10 @@ msgstr ""
 #. Default: "Subscribe to the RSS feed"
 #: ./ftw/news/portlets/templates/news_portlet.pt:43
 msgid "rss_link_title"
+msgstr ""
+
+#. Default: "News"
+#: ./ftw/news/contents/news_folder.py:33
+msgid "title_default_newslisting_block"
 msgstr ""
 

--- a/ftw/news/profiles/default/types/ftw.news.NewsFolder.xml
+++ b/ftw/news/profiles/default/types/ftw.news.NewsFolder.xml
@@ -12,6 +12,12 @@
     <property name="filter_content_types">True</property>
     <property name="allowed_content_types">
         <element value="ftw.news.News"></element>
+        <element value="ftw.news.NewsListingBlock" />
+        <element value="ftw.simplelayout.FileListingBlock" />
+        <element value="ftw.simplelayout.GalleryBlock" />
+        <element value="ftw.simplelayout.MapBlock" />
+        <element value="ftw.simplelayout.TextBlock" />
+        <element value="ftw.simplelayout.VideoBlock" />
     </property>
 
     <property name="schema">ftw.news.contents.news_folder.INewsFolderSchema</property>
@@ -23,11 +29,13 @@
         <element value="plone.app.content.interfaces.INameFromTitle" />
         <element value="plone.app.referenceablebehavior.referenceable.IReferenceable"/>
         <element value="plone.app.dexterity.behaviors.exclfromnav.IExcludeFromNavigation" />
+        <element value="ftw.simplelayout.interfaces.ISimplelayout" />
     </property>
 
-    <property name="immediate_view">news_listing</property>
-    <property name="default_view">news_listing</property>
+    <property name="immediate_view">simplelayout-view</property>
+    <property name="default_view">simplelayout-view</property>
     <property name="view_methods">
+        <element value="simplelayout-view"/>
         <element value="news_listing"/>
     </property>
     <property name="default_view_fallback">False</property>

--- a/ftw/news/tests/mopage_assets/01_export_news.xml
+++ b/ftw/news/tests/mopage_assets/01_export_news.xml
@@ -2,7 +2,7 @@
 <import export_time="2011-01-02 03:04:00">
 
     <item status="1" suchbar="1" mutationsdatum="2010-05-17 16:34:00" datumvon="2010-05-18 12:00:00" datumbis="2020-01-01 00:00:00">
-        <id>uid00000000000000000000000000004</id>
+        <id>uid00000000000000000000000000005</id>
         <url_web>http://nohost/plone/news-folder/largest-aircraft-in-the-world</url_web>
         <titel>Largest Aircraft in the World</titel>
         <textlead></textlead>
@@ -12,7 +12,7 @@
         </textmobile>
     </item>
     <item status="1" suchbar="1" mutationsdatum="2010-03-14 20:18:00" datumvon="2010-03-15 12:00:00">
-        <id>uid00000000000000000000000000002</id>
+        <id>uid00000000000000000000000000003</id>
         <url_web>http://nohost/plone/news-folder/usain-bolt-at-the-olympics</url_web>
         <titel>Usain Bolt at the Ölympics</titel>
         <textlead>&lt;![CDATA[Usain Bolt wins the Ölympic gold in three events.

--- a/ftw/news/tests/test_content_types.py
+++ b/ftw/news/tests/test_content_types.py
@@ -28,6 +28,17 @@ class TestContentTypes(FunctionalTestCase):
                          browser.css('h1.documentFirstHeading').first.text)
 
     @browsing
+    def test_news_folder_has_empty_listing_block(self, browser):
+        self.grant('Manager')
+        folder = create(Builder('news folder'))
+        browser.login().visit(folder)
+        self.assertEqual(
+            ['No content available\n\nMore News'],
+            browser.css('.sl-layout .ftw-news-newslistingblock').text
+        )
+        self.assertEqual(['news'], folder.objectIds())
+
+    @browsing
     def test_add_news_item(self, browser):
         news_folder = create(Builder('news folder'))
 

--- a/ftw/news/tests/test_news_archive_portlets.py
+++ b/ftw/news/tests/test_news_archive_portlets.py
@@ -33,8 +33,10 @@ class TestNewsArchivePortlets(FunctionalTestCase):
 
     @browsing
     def test_archive_portlet_available_when_there_are_news(self, browser):
-        news_folder = create(Builder('news folder').titled(u'News Folder'))
-        create(Builder('news').titled(u'News Entry').within(news_folder))
+        news_folder = create(Builder('news folder').titled(u'News Folder')
+                             .with_property('layout', 'news_listing'))
+        create(Builder('news').titled(u'News Entry').within(news_folder)
+               .with_property('layout', 'news_listing'))
 
         self._add_portlet(browser, news_folder)
 
@@ -43,7 +45,8 @@ class TestNewsArchivePortlets(FunctionalTestCase):
 
     @browsing
     def test_archive_portlet_not_available_when_empty(self, browser):
-        news_folder = create(Builder('news folder').titled(u'News Folder'))
+        news_folder = create(Builder('news folder').titled(u'News Folder')
+                             .with_property('layout', 'news_listing'))
 
         self._add_portlet(browser, news_folder)
 
@@ -55,7 +58,8 @@ class TestNewsArchivePortlets(FunctionalTestCase):
         """
         This test makes sure the summary is correct.
         """
-        news_folder = create(Builder('news folder').titled(u'News Folder'))
+        news_folder = create(Builder('news folder').titled(u'News Folder')
+                             .with_property('layout', 'news_listing'))
         create(Builder('news').titled(u'News Entry 1').within(news_folder)
                .having(news_date=datetime(2013, 1, 1)))
         create(Builder('news').titled(u'News Entry 2').within(news_folder)
@@ -77,7 +81,8 @@ class TestNewsArchivePortlets(FunctionalTestCase):
         """
         The news archive portlet is only rendered on news listing views.
         """
-        news_folder = create(Builder('news folder').titled(u'News Folder'))
+        news_folder = create(Builder('news folder').titled(u'News Folder')
+                             .with_property('layout', 'news_listing'))
         create(Builder('news').titled(u'News Entry 1').within(news_folder))
 
         self._add_portlet(browser)
@@ -90,7 +95,8 @@ class TestNewsArchivePortlets(FunctionalTestCase):
         The news archive portlet is only rendered on news listing views.
         """
         page = create(Builder('sl content page').titled(u'Content Page'))
-        news_folder = create(Builder('news folder').titled(u'News Folder'))
+        news_folder = create(Builder('news folder').titled(u'News Folder')
+                             .with_property('layout', 'news_listing'))
         create(Builder('news').titled(u'News Entry 1').within(news_folder))
 
         self._add_portlet(browser, page)
@@ -102,7 +108,8 @@ class TestNewsArchivePortlets(FunctionalTestCase):
         """
         This test makes sure the summary is correct.
         """
-        news_folder = create(Builder('news folder').titled(u'News Folder'))
+        news_folder = create(Builder('news folder').titled(u'News Folder')
+                             .with_property('layout', 'news_listing'))
         create(Builder('news').titled(u'News Entry 1').within(news_folder)
                .having(news_date=datetime(2013, 1, 1)))
         create(Builder('news').titled(u'News Entry 2').within(news_folder)
@@ -119,7 +126,8 @@ class TestNewsArchivePortlets(FunctionalTestCase):
         lang_tool.setDefaultLanguage('de')
         transaction.commit()
 
-        news_folder = create(Builder('news folder').titled(u'News Folder'))
+        news_folder = create(Builder('news folder').titled(u'News Folder')
+                             .with_property('layout', 'news_listing'))
         create(Builder('news').titled(u'News Entry 1').within(news_folder)
                .having(news_date=datetime(2013, 3, 1)))
 

--- a/ftw/news/tests/test_news_listing.py
+++ b/ftw/news/tests/test_news_listing.py
@@ -21,7 +21,8 @@ class TestNewsListing(FunctionalTestCase):
         self.grant('Manager')
 
         self.news_folder = create(Builder('news folder')
-                                  .titled(u'A News Folder'))
+                                  .titled(u'A News Folder')
+                                  .with_property('layout', 'news_listing'))
 
         yesterday = datetime.now() - timedelta(days=1)
         self.news1 = create(Builder('news')
@@ -103,7 +104,8 @@ class TestNewsListing(FunctionalTestCase):
         view "@@news_listing" is called on a news folder.
         """
         news_folder = create(Builder(u'news folder')
-                             .titled(u'A News Folder'))
+                             .titled(u'A News Folder')
+                             .with_property('layout', 'news_listing'))
         browser.visit(news_folder)
         self.assertEquals(u'A News Folder', plone.first_heading())
 
@@ -155,13 +157,14 @@ class TestNewsListingFormat(FunctionalTestCase):
         super(TestNewsListingFormat, self).setUp()
         self.grant('Manager')
 
-        self.news_folder = create(Builder('news folder'))
+        self.news_folder = create(Builder('news folder')
+                                  .with_property('layout', 'news_listing'))
 
     @browsing
     def test_show_full_creation_date_if_hour_and_minute_are_set(self, browser):
         create(Builder('news')
-            .within(self.news_folder)
-            .having(news_date=DateTime('2015/03/13 16:15')))
+               .within(self.news_folder)
+               .having(news_date=DateTime('2015/03/13 16:15')))
 
         browser.login().open(self.news_folder)
 
@@ -170,8 +173,8 @@ class TestNewsListingFormat(FunctionalTestCase):
     @browsing
     def test_show_full_creation_date_if_minute_is_not_set(self, browser):
         create(Builder('news')
-            .within(self.news_folder)
-            .having(news_date=DateTime('2015/03/13 16:00')))
+               .within(self.news_folder)
+               .having(news_date=DateTime('2015/03/13 16:00')))
 
         browser.login().open(self.news_folder)
 
@@ -180,8 +183,8 @@ class TestNewsListingFormat(FunctionalTestCase):
     @browsing
     def test_show_full_creation_date_if_hour_is_not_set(self, browser):
         create(Builder('news')
-            .within(self.news_folder)
-            .having(news_date=DateTime('2015/03/13 00:15')))
+               .within(self.news_folder)
+               .having(news_date=DateTime('2015/03/13 00:15')))
 
         browser.login().open(self.news_folder)
 
@@ -190,8 +193,8 @@ class TestNewsListingFormat(FunctionalTestCase):
     @browsing
     def test_show_no_time_if_minute_and_hour_are_not_set(self, browser):
         create(Builder('news')
-            .within(self.news_folder)
-            .having(news_date=DateTime('2015/03/13 00:00')))
+               .within(self.news_folder)
+               .having(news_date=DateTime('2015/03/13 00:00')))
 
         browser.login().open(self.news_folder)
 

--- a/ftw/news/upgrades/20160919093427_use_simplelayout_for_news_folders/types/ftw.news.NewsFolder.xml
+++ b/ftw/news/upgrades/20160919093427_use_simplelayout_for_news_folders/types/ftw.news.NewsFolder.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0"?>
+<object name="ftw.news.NewsFolder"
+        meta_type="Dexterity FTI"
+        xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+        i18n:domain="ftw.news">
+
+    <property name="allowed_content_types" purge="False">
+        <element value="ftw.news.NewsListingBlock" />
+        <element value="ftw.simplelayout.FileListingBlock" />
+        <element value="ftw.simplelayout.GalleryBlock" />
+        <element value="ftw.simplelayout.MapBlock" />
+        <element value="ftw.simplelayout.TextBlock" />
+        <element value="ftw.simplelayout.VideoBlock" />
+    </property>
+
+    <property name="behaviors" purge="False">
+        <element value="ftw.simplelayout.interfaces.ISimplelayout" />
+    </property>
+
+    <property name="immediate_view">simplelayout-view</property>
+    <property name="default_view">simplelayout-view</property>
+    <property name="view_methods">
+        <element value="simplelayout-view"/>
+        <element value="news_listing"/>
+    </property>
+
+</object>

--- a/ftw/news/upgrades/20160919093427_use_simplelayout_for_news_folders/upgrade.py
+++ b/ftw/news/upgrades/20160919093427_use_simplelayout_for_news_folders/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class UseSimplelayoutForNewsFolders(UpgradeStep):
+    """Use simplelayout for news folders.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()


### PR DESCRIPTION
- Use simplelayout-view as default view for news folder but keep `news_listing`-view in allowed layouts.
- Make simplelayout blocks addable.
- Auto-create a news listing block when creating a news folder.
- Update tests for `news_listing`-view and for portlets (view must be chosen).