### PR TITLE
Mopage endpoint: remove web_url-tag as it is unecessary.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,8 @@ Changelog
 1.3.2 (unreleased)
 ------------------
 
+- Mopage endpoint: remove web_url-tag as it is ambiguous. [jone]
+
 - Improve mopage body by using simple HTML. [jone]
 
 - Use simplelayout by default for news folders. [jone]

--- a/ftw/news/browser/templates/mopage_news.pt
+++ b/ftw/news/browser/templates/mopage_news.pt
@@ -17,7 +17,6 @@
           status="1"
           suchbar="1">
         <id tal:content="item/uid" />
-        <url_web tal:content="item/url" />
         <titel tal:content="item/title" />
         <textlead tal:content="item/textlead" />
         <url_bild tal:content="item/image_url" tal:condition="item/image_url" />

--- a/ftw/news/tests/mopage_assets/01_export_news.xml
+++ b/ftw/news/tests/mopage_assets/01_export_news.xml
@@ -3,7 +3,6 @@
 
     <item status="1" suchbar="1" mutationsdatum="2010-05-17 16:34:00" datumvon="2010-05-18 12:00:00" datumbis="2020-01-01 00:00:00">
         <id>uid00000000000000000000000000005</id>
-        <url_web>http://nohost/plone/news-folder/largest-aircraft-in-the-world</url_web>
         <titel>Largest Aircraft in the World</titel>
         <textlead></textlead>
 
@@ -13,7 +12,6 @@
     </item>
     <item status="1" suchbar="1" mutationsdatum="2010-03-14 20:18:00" datumvon="2010-03-15 12:00:00">
         <id>uid00000000000000000000000000003</id>
-        <url_web>http://nohost/plone/news-folder/usain-bolt-at-the-olympics</url_web>
         <titel>Usain Bolt at the Ölympics</titel>
         <textlead>&lt;![CDATA[Usain Bolt wins the Ölympic gold in three events.
 


### PR DESCRIPTION
According to anthrazit the `<web_url>`-tag is unecessary.
It generates a "Website anzeigen" link.
Since we include the news body text, there is no purpose in such a link.