### PR TITLE
Mopage trigger: trigger on any update of the news.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,8 @@ Changelog
 1.3.2 (unreleased)
 ------------------
 
+- Mopage trigger: trigger on any update of the news. [jone]
+
 - Mopage endpoint: remove web_url-tag as it is ambiguous. [jone]
 
 - Improve mopage body by using simple HTML. [jone]

--- a/ftw/news/behaviors/configure.zcml
+++ b/ftw/news/behaviors/configure.zcml
@@ -35,12 +35,12 @@
     <configure zcml:condition="have ftw.news:mopage_publisher_receiver">
 
         <subscriber
-            for="ftw.news.interfaces.INews
+            for="*
                  ftw.publisher.receiver.interfaces.IAfterCreatedEvent"
             handler=".mopage.trigger_mopage_refresh" />
 
         <subscriber
-            for="ftw.news.interfaces.INews
+            for="*
                  ftw.publisher.receiver.interfaces.IAfterUpdatedEvent"
             handler=".mopage.trigger_mopage_refresh" />
 

--- a/ftw/news/behaviors/mopage.py
+++ b/ftw/news/behaviors/mopage.py
@@ -1,5 +1,6 @@
 from Acquisition import aq_chain
 from ftw.news import _
+from ftw.news.interfaces import INews
 from plone.app.dexterity.behaviors.metadata import DCFieldProperty
 from plone.app.dexterity.behaviors.metadata import MetadataBase
 from plone.autoform.directives import read_permission
@@ -105,10 +106,17 @@ class PublisherMopageTrigger(MetadataBase):
         return urlparse.urlunparse(parts)
 
 
-def trigger_mopage_refresh(news, event):
+def trigger_mopage_refresh(obj, event):
+    if not filter(None,
+                  map(lambda parent: INews(parent, None),
+                      aq_chain(obj))):
+        # We are not within a news.
+        # We only trigger when publishing a news or a child of a news.
+        return
+
     triggers = filter(None,
-                      map(lambda obj: IPublisherMopageTrigger(obj, None),
-                          aq_chain(news)))
+                      map(lambda parent: IPublisherMopageTrigger(parent, None),
+                          aq_chain(obj)))
     if not triggers or not triggers[0].is_enabled():
         return
 


### PR DESCRIPTION
Trigger the mopage endpoint on any update of the news.
This now also includes adding new children (simplelayout blocks).
This is important because when the news itself is created it does not
yet have any content (=simplelayout blocks).
If the data is pulled from the mopage endpoint at this point the news
will not have any content.

This change will result in multiple updates when creating or updating a
news, which will make sure that everything is up to date in the end.
Since we cannot tell for sure in advance how many changes we will have
it is hard to merge them. In order to have a consistent state at the end
we therefore do not merge them at all.