### PR TITLE
Mopage: track content changes.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.4.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Mopage: add custom modified date for tracking content changes. [jone]
 
 
 1.4.0 (2016-09-26)

--- a/ftw/news/behaviors/configure.zcml
+++ b/ftw/news/behaviors/configure.zcml
@@ -52,6 +52,12 @@
             permission="zope2.View"
             />
 
+        <adapter
+            for="ftw.news.interfaces.INews"
+            provides="ftw.news.behaviors.mopage.IMopageModificationDate"
+            factory="ftw.news.behaviors.mopage.MopageModificationDate"
+            />
+
     </configure>
 
 </configure>

--- a/ftw/news/browser/mopage.py
+++ b/ftw/news/browser/mopage.py
@@ -1,4 +1,5 @@
 from DateTime import DateTime
+from ftw.news.behaviors.mopage import IMopageModificationDate
 from plone.app.dexterity.behaviors.metadata import ICategorization
 from plone.uuid.interfaces import IUUID
 from Products.CMFCore.utils import getToolByName
@@ -117,10 +118,11 @@ class MopageNews(BrowserView):
 
         subjects = getattr(ICategorization(obj, None), 'subjects', ())
 
+        modified_date = IMopageModificationDate(obj).get_date()
         return {'title': crop(100, brain.Title),
                 'news_date': self.normalize_date(brain.start),
                 'expires': self.normalize_date(brain.expires),
-                'modified_date': self.normalize_date(brain.modified),
+                'modified_date': self.normalize_date(modified_date),
                 'uid': IUUID(obj),
                 'url': brain.getURL(),
                 'textlead': textlead,

--- a/ftw/news/tests/mopage_assets/01_export_news.xml
+++ b/ftw/news/tests/mopage_assets/01_export_news.xml
@@ -10,7 +10,7 @@
             <![CDATA[]]>
         </textmobile>
     </item>
-    <item status="1" suchbar="1" mutationsdatum="2010-03-14 20:18:00" datumvon="2010-03-15 12:00:00">
+    <item status="1" suchbar="1" mutationsdatum="2010-03-15 00:00:00" datumvon="2010-03-15 12:00:00">
         <id>uid00000000000000000000000000003</id>
         <titel>Usain Bolt at the Ölympics</titel>
         <textlead>&lt;![CDATA[Usain Bolt wins the Ölympic gold in three events.

--- a/ftw/news/tests/test_mopage.py
+++ b/ftw/news/tests/test_mopage.py
@@ -1,6 +1,8 @@
 from datetime import datetime
+from DateTime import DateTime
 from ftw.builder import Builder
 from ftw.builder import create
+from ftw.news.behaviors.mopage import IMopageModificationDate
 from ftw.news.tests import FunctionalTestCase
 from ftw.news.tests import utils
 from ftw.news.tests import XMLDiffTestCase
@@ -36,6 +38,7 @@ class TestMopageExport(FunctionalTestCase, XMLDiffTestCase):
                            .with_dummy_image()
                            .having(text=lorem))
             utils.create_page_state(news1, block)
+            IMopageModificationDate(news1).set_date(DateTime('2010/3/15'))
 
         with freeze(datetime(2010, 5, 17, 15, 34)):
             create(Builder('news')


### PR DESCRIPTION
Since the trigger triggers when adding the news and for each added content block separately, we need to update the modification date in the data endpoint accordingly in order to let the remote system track changes and update correctly.
Since Plone's modification date does not and should not change when the publisher adds content blocks, we need to track those modification separately in our own modification date.