### PR TITLE
Fix chameleon support for mopage export.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.4.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix chameleon support for mopage export. [jone]
 
 
 1.4.2 (2016-10-18)

--- a/ftw/news/browser/templates/mopage_news.pt
+++ b/ftw/news/browser/templates/mopage_news.pt
@@ -2,13 +2,13 @@
 <import xmlns:tal="http://xml.zope.org/namespaces/tal"
         xmlns:i18n="http://xml.zope.org/namespaces/i18n"
         i18n:domain="ftw.news"
-        tal:define="attrs view/import_node_attributes"
-        tal:attributes="export_time attrs/export_time;
-                        partner attrs/partner;
-                        partnerid attrs/partnerid;
-                        passwort attrs/passwort;
-                        importid attrs/importid;
-                        vaterobjekt attrs/vaterobjekt">
+        tal:define="attributes view/import_node_attributes"
+        tal:attributes="export_time attributes/export_time;
+                        partner attributes/partner;
+                        partnerid attributes/partnerid;
+                        passwort attributes/passwort;
+                        importid attributes/importid;
+                        vaterobjekt attributes/vaterobjekt">
 
     <item tal:repeat="item view/items"
           tal:attributes="datumvon item/news_date;

--- a/ftw/news/tests/test_news_listing_rss.py
+++ b/ftw/news/tests/test_news_listing_rss.py
@@ -55,7 +55,7 @@ class TestNewsRssListing(FunctionalTestCase):
 
         browser.login().visit(news_folder, view='news_listing_rss')
 
-        rdf = '<rdf:li rdf:resource="{0}"/>'.format(news.absolute_url())
+        rdf = '<rdf:li rdf:resource="{0}"'.format(news.absolute_url())
         self.assertIn(rdf, browser.contents,
                       'Did not found the rdf tag for the news')
 

--- a/setup.py
+++ b/setup.py
@@ -6,13 +6,14 @@ maintainer = 'Mathias Leimgruber'
 
 tests_require = [
     'ftw.builder',
+    'ftw.chameleon',
+    'ftw.news[mopage_publisher_receiver]',
     'ftw.subsite',
     'ftw.testbrowser',
     'ftw.testing>=1.11.0',
     'path.py',
     'plone.app.testing',
     'plone.testing',
-    'ftw.news[mopage_publisher_receiver]',
 ]
 
 extras_require = {


### PR DESCRIPTION
When using the variable name "attrs", chameleon does no longer evaluate the expression.