### PR TITLE
Do not show news time.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.4.4 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Do not show news time. [jone]
 
 
 1.4.3 (2016-10-20)

--- a/ftw/news/browser/news_listing.py
+++ b/ftw/news/browser/news_listing.py
@@ -99,10 +99,7 @@ class NewsListing(BrowserView):
                  mapping={'title': self.context.Title().decode('utf-8')})
 
     def format_date(self, brain):
-        show_long_format = (DateTime(brain.start).hour()
-                            or DateTime(brain.start).minute())
-        return self.context.toLocalizedTime(brain.start,
-                                            long_format=show_long_format)
+        return self.context.toLocalizedTime(brain.start, long_format=False)
 
 
 class NewsListingRss(NewsListing):

--- a/ftw/news/browser/news_listing_block.py
+++ b/ftw/news/browser/news_listing_block.py
@@ -124,4 +124,4 @@ class NewsListingBlockView(BaseBlock):
         return item
 
     def format_date(self, brain):
-        return self.context.toLocalizedTime(brain.start, long_format=True)
+        return self.context.toLocalizedTime(brain.start, long_format=False)

--- a/ftw/news/portlets/news_portlet.py
+++ b/ftw/news/portlets/news_portlet.py
@@ -196,7 +196,7 @@ class Renderer(base.Renderer):
         return item
 
     def format_date(self, brain):
-        return self.context.toLocalizedTime(brain.start, long_format=True)
+        return self.context.toLocalizedTime(brain.start, long_format=False)
 
     def show_rss_link(self):
         return getattr(self.data, 'show_rss_link', False)

--- a/ftw/news/tests/test_content_types.py
+++ b/ftw/news/tests/test_content_types.py
@@ -61,6 +61,6 @@ class TestContentTypes(FunctionalTestCase):
 
         browser.login().open(news)
         self.assertEqual(
-            'May 07, 2001 11:13 AM',
+            'May 07, 2001',
             browser.css('.news-date').first.text
         )

--- a/ftw/news/tests/test_mopage.py
+++ b/ftw/news/tests/test_mopage.py
@@ -94,13 +94,15 @@ class TestMopageExport(FunctionalTestCase, XMLDiffTestCase):
     @browsing
     def test_export_all_news_on_site(self, browser):
         self.grant('Manager')
-        create(Builder('news').titled(u'One').within(
-            create(Builder('news folder').titled(u'News Folder One'))))
-        create(Builder('news').titled(u'Two').within(
-            create(Builder('news folder').titled(u'News Folder Two'))))
+        with freeze(datetime(2015, 10, 1)) as clock:
+            create(Builder('news').titled(u'One').within(
+                create(Builder('news folder').titled(u'News Folder One'))))
+            clock.forward(days=1)
+            create(Builder('news').titled(u'Two').within(
+                create(Builder('news folder').titled(u'News Folder Two'))))
 
         browser.open(self.portal, view='mopage.news.xml')
-        self.assert_news_in_browser(['One', 'Two'])
+        self.assert_news_in_browser(['Two', 'One'])
 
     @browsing
     def test_title_is_cropped(self, browser):

--- a/ftw/news/tests/test_news_detail.py
+++ b/ftw/news/tests/test_news_detail.py
@@ -27,7 +27,7 @@ class TestNewsDetail(FunctionalTestCase):
 
         browser.login().visit(news)
         self.assertEqual(
-            'Dec 31, 2000 01:00 PM',
+            'Dec 31, 2000',
             browser.css('.news-date').first.text
         )
 
@@ -40,40 +40,10 @@ class TestDateTimeFormat(FunctionalTestCase):
         self.news_folder = create(Builder('news folder'))
 
     @browsing
-    def test_show_full_creation_date_if_hour_and_minute_are_set(self, browser):
+    def test_show_date_in_short_format(self, browser):
         news = create(Builder('news')
             .within(self.news_folder)
             .having(news_date=DateTime('2015/03/13 16:15')))
-
-        browser.login().open(news)
-
-        self.assertEquals('Mar 13, 2015 04:15 PM', browser.css('.news-date').first.text)
-
-    @browsing
-    def test_show_full_creation_date_if_minute_is_not_set(self, browser):
-        news = create(Builder('news')
-            .within(self.news_folder)
-            .having(news_date=DateTime('2015/03/13 16:00')))
-
-        browser.login().open(news)
-
-        self.assertEquals('Mar 13, 2015 04:00 PM', browser.css('.news-date').first.text)
-
-    @browsing
-    def test_show_full_creation_date_if_hour_is_not_set(self, browser):
-        news = create(Builder('news')
-            .within(self.news_folder)
-            .having(news_date=DateTime('2015/03/13 00:15')))
-
-        browser.login().open(news)
-
-        self.assertEquals('Mar 13, 2015 12:15 AM', browser.css('.news-date').first.text)
-
-    @browsing
-    def test_show_no_time_if_minute_and_hour_are_not_set(self, browser):
-        news = create(Builder('news')
-            .within(self.news_folder)
-            .having(news_date=DateTime('2015/03/13 00:00')))
 
         browser.login().open(news)
 

--- a/ftw/news/tests/test_news_listing.py
+++ b/ftw/news/tests/test_news_listing.py
@@ -168,7 +168,7 @@ class TestNewsListingFormat(FunctionalTestCase):
 
         browser.login().open(self.news_folder)
 
-        self.assertEquals('Mar 13, 2015 04:15 PM', browser.css('.dtstart').first.text)
+        self.assertEquals('Mar 13, 2015', browser.css('.dtstart').first.text)
 
     @browsing
     def test_show_full_creation_date_if_minute_is_not_set(self, browser):
@@ -178,7 +178,7 @@ class TestNewsListingFormat(FunctionalTestCase):
 
         browser.login().open(self.news_folder)
 
-        self.assertEquals('Mar 13, 2015 04:00 PM', browser.css('.dtstart').first.text)
+        self.assertEquals('Mar 13, 2015', browser.css('.dtstart').first.text)
 
     @browsing
     def test_show_full_creation_date_if_hour_is_not_set(self, browser):
@@ -188,7 +188,7 @@ class TestNewsListingFormat(FunctionalTestCase):
 
         browser.login().open(self.news_folder)
 
-        self.assertEquals('Mar 13, 2015 12:15 AM', browser.css('.dtstart').first.text)
+        self.assertEquals('Mar 13, 2015', browser.css('.dtstart').first.text)
 
     @browsing
     def test_show_no_time_if_minute_and_hour_are_not_set(self, browser):

--- a/ftw/news/tests/test_news_listing_block.py
+++ b/ftw/news/tests/test_news_listing_block.py
@@ -167,7 +167,7 @@ class TestNewsListingBlockContentType(FunctionalTestCase):
         set_allow_anonymous_view_about(False)
 
         browser.login(self.member).open(self.page)
-        self.assertEqual('Dec 31, 2000 03:00 PM by test_user_1_',
+        self.assertEqual('Dec 31, 2000 by test_user_1_',
                          browser.css('.news-item .byline').first.text,
                          'Authenticated member should see author if '
                          'allowAnonymousViewAbout is False.')
@@ -179,7 +179,7 @@ class TestNewsListingBlockContentType(FunctionalTestCase):
         set_allow_anonymous_view_about(True)
 
         browser.login(self.member).open(self.page)
-        self.assertEqual('Dec 31, 2000 03:00 PM by test_user_1_',
+        self.assertEqual('Dec 31, 2000 by test_user_1_',
                          browser.css('.news-item .byline').first.text,
                          'Authenticated member should see author.')
 
@@ -190,7 +190,7 @@ class TestNewsListingBlockContentType(FunctionalTestCase):
         set_allow_anonymous_view_about(False)
 
         browser.logout().open(self.page)
-        self.assertEqual('Dec 31, 2000 03:00 PM',
+        self.assertEqual('Dec 31, 2000',
                          browser.css('.news-item .byline').first.text,
                          'Anonymous user should not see author if '
                          'allowAnonymousViewAbout is False.')
@@ -202,7 +202,7 @@ class TestNewsListingBlockContentType(FunctionalTestCase):
         set_allow_anonymous_view_about(True)
 
         browser.logout().open(self.page)
-        self.assertEqual('Dec 31, 2000 03:00 PM by test_user_1_',
+        self.assertEqual('Dec 31, 2000 by test_user_1_',
                          browser.css('.news-item .byline').first.text,
                          'Anonymous user should see author if '
                          'allowAnonymousViewAbout is True.')

--- a/ftw/news/viewlets/news_date.py
+++ b/ftw/news/viewlets/news_date.py
@@ -1,4 +1,3 @@
-from DateTime import DateTime
 from ftw.news.contents.news import INewsSchema
 from plone.app.layout.viewlets import ViewletBase
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
@@ -20,8 +19,4 @@ class NewsDateViewlet(ViewletBase):
 
         if not news_date:
             return ''
-
-        show_long_format = (DateTime(news_date).hour()
-                            or DateTime(news_date).minute())
-        return self.context.toLocalizedTime(news_date,
-                                            long_format=show_long_format)
+        return self.context.toLocalizedTime(news_date, long_format=False)


### PR DESCRIPTION
In our experience, customers do not want to display the news time but only the news date.