### PR TITLE
Mopage: fix textlead max length

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,8 @@ Changelog
 1.4.6 (unreleased)
 ------------------
 
+- Mopage: fix textlead max length (from 100 to 1000). [jone]
+
 - Fix news item class identifier.
   [Kevin Bieri]
 

--- a/ftw/news/browser/mopage.py
+++ b/ftw/news/browser/mopage.py
@@ -135,7 +135,7 @@ class MopageNews(BrowserView):
             # sorry, not supported.
             image_url = None
 
-        textlead = crop(100, obj.Description() or '')
+        textlead = crop(1000, obj.Description() or '')
         if textlead:
             textlead = u'<![CDATA[{}]]>'.format(textlead)
 


### PR DESCRIPTION
The maxlength of the textlead field is 1000, not 100.

According to specs: http://doc.mopage.ch/ext/XML_Schnittstelle/3_Verschiedene_Seitentypen/1_News