### PR TITLE
Fix filter for subjects containing umlauts in newslistingblock.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 1.4.6 (unreleased)
 ------------------
 
+- Fix filter for subjects containing umlauts in newslistingblock.
+  [mathias.leimgruber]
+
 - Mopage: fix textlead max length (from 100 to 1000). [jone]
 
 - Fix news item class identifier.

--- a/ftw/news/browser/news_listing_block.py
+++ b/ftw/news/browser/news_listing_block.py
@@ -1,13 +1,14 @@
 from Acquisition._Acquisition import aq_inner, aq_parent
 from DateTime.DateTime import DateTime
-from Products.CMFCore.utils import getToolByName
-from Products.CMFPlone.interfaces import IPloneSiteRoot
-from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from ftw.news import _
 from ftw.news import utils
 from ftw.news.behaviors.show_on_homepage.news import IShowOnHomepage
 from ftw.news.contents.common import INewsListingBaseSchema
+from ftw.news.utils import make_utf8
 from ftw.simplelayout.browser.blocks.base import BaseBlock
+from Products.CMFCore.utils import getToolByName
+from Products.CMFPlone.interfaces import IPloneSiteRoot
+from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from zope.i18n import translate
 
 
@@ -75,8 +76,9 @@ class NewsListingBlockView(BaseBlock):
                 cat_path.append('/'.join([portal_path, item]))
             query['path'] = {'query': cat_path}
 
-        if self.context.subjects:
-            query['Subject'] = self.context.subjects
+        subjects = self.context.subjects
+        if subjects:
+            query['Subject'] = map(make_utf8, subjects)
 
         if self.context.maximum_age > 0:
             date = DateTime() - self.context.maximum_age

--- a/ftw/news/tests/test_news_listing_listingblock.py
+++ b/ftw/news/tests/test_news_listing_listingblock.py
@@ -50,3 +50,18 @@ class TestNewsListingOnNewsListingBlock(FunctionalTestCase):
                                         DateTime('2014/12/31').latestTime()),
                               'range': 'minmax'},
                              news_listing_view.get_query()['start'])
+
+    def test_query_newslisting_with_subject_containing_umlauts(self):
+        newsfolder = create(Builder('news folder').within(self.page))
+        news = create(Builder('news')
+                      .within(newsfolder)
+                      .titled(u'Some News')
+                      .having(subjects=('F\xc3\xb6\xc3\xb6', 'Bar')))
+        newslistingblock = create(Builder('news listing block')
+                                  .within(self.page)
+                                  .titled(u'News listing block')
+                                  .having(subjects=(u'F\xf6\xf6', 'Bar')))
+
+        view = newslistingblock.restrictedTraverse('block_view')
+        self.assertTrue(len(view.get_news()), 'Expect one news item')
+        self.assertEquals(news.Title(), view.get_news()[0]['title'])

--- a/ftw/news/utils.py
+++ b/ftw/news/utils.py
@@ -45,3 +45,10 @@ def crop_text(text, length):
     """
     plone_view = api.portal.get().restrictedTraverse('@@plone')
     return plone_view.cropText(text, length)
+
+
+def make_utf8(item):
+    if isinstance(item, unicode):
+        return item.encode('utf-8')
+    else:
+        return item


### PR DESCRIPTION
`self.context.subjects` may contain unicode, but the catalog does not like unicode.

This fixes the following error, after try to filer for a subjects containing umlauts in newslistingblock.

``` 
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 2: ordinal not in range(128)
  File "ZPublisher/Publish.py", line 138, in publish
    request, bind=1)
  File "ZPublisher/mapply.py", line 77, in mapply
    if debug is not None: return debug(object,args,context)
  File "ZPublisher/Publish.py", line 48, in call_object
    result=apply(object,args) # Type s<cr> to step into published object.
  File "home/zope/eggs/plone.formwidget.autocomplete-1.2.9-py2.7.egg/plone/formwidget/autocomplete/widget.py", line 63, in __call__
    terms = set(source.search(query))
  File "home/zope/eggs/plone.formwidget.autocomplete-1.2.9-py2.7.egg/plone/formwidget/autocomplete/demo.py", line 42, in search
    return [self.getTerm(kw) for kw in self.keywords if q in kw.lower()]

UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 2: ordinal not in range(128)
``` 