### PR TITLE
Fix small rst syntax error in readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -107,7 +107,7 @@ with the newly availabe fields.
 
 
 Development
-==========
+===========
 
 **Python:**
 

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.4.7 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix small RST Syntax error in readme file. [raphael-s]
 
 
 1.4.6 (2016-12-06)


### PR DESCRIPTION
This led to the readme not being displayed right on pypi. Strangely this didn't affect github...

<img width="566" alt="screen shot 2016-12-16 at 16 03 41" src="https://cloud.githubusercontent.com/assets/16755391/21267136/47e1b67a-c3a9-11e6-815b-eac31c2f066b.png">
