### PR TITLE
Add behavior "external url" to news items.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.5.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Add a new field on news items which can be used to define a custom external
+  url (useful for mobile apps). [mbaechtold]
 
 
 1.5.0 (2017-01-11)

--- a/ftw/news/behaviors/configure.zcml
+++ b/ftw/news/behaviors/configure.zcml
@@ -32,6 +32,13 @@
         factory="ftw.news.behaviors.mopage.PublisherMopageTrigger"
         />
 
+    <plone:behavior
+        title="External URL (for mobile app)"
+        description="Provides an additional URL field for mobile apps"
+        provides=".external_url.INewsExternalUrl"
+        for="ftw.news.interfaces.INews"
+        />
+
     <configure zcml:condition="have ftw.news:mopage_publisher_receiver">
 
         <subscriber

--- a/ftw/news/behaviors/external_url.py
+++ b/ftw/news/behaviors/external_url.py
@@ -1,0 +1,18 @@
+from ftw.news import _
+from plone.autoform.directives import write_permission
+from plone.autoform.interfaces import IFormFieldProvider
+from plone.directives import form
+from zope import schema
+from zope.interface import provider
+
+
+@provider(IFormFieldProvider)
+class INewsExternalUrl(form.Schema):
+
+    write_permission(external_url='ftw.news.EditNewsExternalUrl')
+    external_url = schema.URI(
+        title=_(u'label_news_external_url',
+                default=u'External link for mobile app'),
+        default=None,
+        required=False,
+    )

--- a/ftw/news/browser/mopage.py
+++ b/ftw/news/browser/mopage.py
@@ -1,4 +1,5 @@
 from DateTime import DateTime
+from ftw.news.behaviors.external_url import INewsExternalUrl
 from ftw.news.behaviors.mopage import IMopageModificationDate
 from htmlentitydefs import name2codepoint as n2cp
 from plone.app.dexterity.behaviors.metadata import ICategorization
@@ -147,7 +148,7 @@ class MopageNews(BrowserView):
                 'expires': self.normalize_date(brain.expires),
                 'modified_date': self.normalize_date(modified_date),
                 'uid': IUUID(obj),
-                'url': brain.getURL(),
+                'web_url': getattr(INewsExternalUrl(obj, None), 'external_url', ''),
                 'textlead': textlead,
                 'image_url': image_url,
                 'subjects': map(lambda subject: crop(100, subject), subjects),

--- a/ftw/news/browser/templates/mopage_news.pt
+++ b/ftw/news/browser/templates/mopage_news.pt
@@ -19,6 +19,7 @@
         <id tal:content="item/uid" />
         <titel tal:content="item/title" />
         <textlead tal:content="structure item/textlead" />
+        <web_url tal:condition="item/web_url" tal:content="item/web_url" />
         <url_bild tal:content="item/image_url" tal:condition="item/image_url" />
         <textmobile tal:define="context nocall:item/obj;
                                 html simplelayout:default">

--- a/ftw/news/lawgiver.zcml
+++ b/ftw/news/lawgiver.zcml
@@ -26,4 +26,9 @@
         permissions="ftw.news: Configure mopage trigger"
         />
 
+    <lawgiver:map_permissions
+        action_group="edit news external url"
+        permissions="ftw.news: Edit news external url"
+        />
+
 </configure>

--- a/ftw/news/locales/de/LC_MESSAGES/ftw.news.po
+++ b/ftw/news/locales/de/LC_MESSAGES/ftw.news.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-09-19 12:57+0000\n"
+"POT-Creation-Date: 2017-01-11 08:29+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -30,6 +30,10 @@ msgstr "Archiv"
 msgid "Display the contents of a news folder."
 msgstr ""
 
+#: ./ftw/news/behaviors/configure.zcml:40
+msgid "External URL (for mobile app)"
+msgstr "Externe URL (für Mobile-App)"
+
 #: ./ftw/news/configure.zcml:38
 msgid "Installs a feature allowing to mark news to show on homepage."
 msgstr "Installiert ein zusätzliches Feature für die Anzeige von News-Einträgen auf der Startseite."
@@ -42,7 +46,7 @@ msgstr "News-Einträge für Anzeige auf Startseite markieren"
 msgid "Mark news listing block to render news on homepage"
 msgstr ""
 
-#: ./ftw/news/behaviors/mopage.py:23
+#: ./ftw/news/behaviors/mopage.py:27
 msgid "Mopage"
 msgstr "Mopage"
 
@@ -78,6 +82,10 @@ msgstr "News-Auflistung"
 msgid "No content available"
 msgstr "Kein Inhalt verfügbar"
 
+#: ./ftw/news/behaviors/configure.zcml:40
+msgid "Provides an additional URL field for mobile apps"
+msgstr "Stellt ein usätzliches URL-Feld für Mobile-Apps zur Verfügung."
+
 #: ./ftw/news/behaviors/configure.zcml:33
 msgid "Provides fields for configuring a mopage trigger (ftw.publisher)."
 msgstr "Felder für die Konfiguration des Mopage Auslösers."
@@ -95,12 +103,12 @@ msgid "The news listing block renders a configurable list of news entries."
 msgstr "Der Newsauflistungsblock zeigt eine konfigurierbare Liste von Nachrichten-Meldungen an."
 
 #. Default: "The mopage data endpoint URL points to the \"mopage.news.xml\" view somewhere on the public visible  Plone page. It must also contain the params \"partnerid\" and \"importid\". Example: https://mypage.ch/news/mopage.news.xml?partnerid=3&importid=6"
-#: ./ftw/news/behaviors/mopage.py:59
+#: ./ftw/news/behaviors/mopage.py:63
 msgid "description_mopage_data_endpoint_url"
 msgstr "Die Mopage Endpoint-URL zeigt auf die \"mopage.news.xml\"-Ansicht eines News-Ordners auf Plone. Die URL muss die Parameter \"partnerid\" und \"importid\" enthalten. Die URL muss vollständig sein und auf die öffentliche Seite zeigen. Beispiel: https://mypage.ch/news/mopage.news.xml?partnerid=3&importid=6"
 
 #. Default: "Contains the mopage URL to the trigger endpoint. This is only the base URL, it does not contain the endpoint URL from which the mopage server retrieves the news. Example: https://un:pw@xml.mopage.ch/infoservice/xml.php"
-#: ./ftw/news/behaviors/mopage.py:42
+#: ./ftw/news/behaviors/mopage.py:46
 msgid "description_mopage_trigger_url"
 msgstr "Die Trigger-URL zeigt auf die Mopage-API. Sie enthält kein \"?url\"-Parameter, dieser wird automatisch angefügt. Beispiel: https://un:pw@xml.mopage.ch/infoservice/xml.php"
 
@@ -128,12 +136,12 @@ msgid "label_feed_desc"
 msgstr "${title} - News Feed"
 
 #. Default: "Mopage data endpoint URL (Plone)"
-#: ./ftw/news/behaviors/mopage.py:57
+#: ./ftw/news/behaviors/mopage.py:61
 msgid "label_mopage_data_endpoint_url"
 msgstr "Mopage: URL zu Daten-Endpoint"
 
 #. Default: "Mopage trigger URL"
-#: ./ftw/news/behaviors/mopage.py:40
+#: ./ftw/news/behaviors/mopage.py:44
 msgid "label_mopage_trigger_url"
 msgstr "Mopage Trigger URL"
 
@@ -142,13 +150,18 @@ msgstr "Mopage Trigger URL"
 msgid "label_more_news_link_label"
 msgstr "Label für den Link \"Weitere Einträge\""
 
+#. Default: "External link for mobile app"
+#: ./ftw/news/behaviors/external_url.py:14
+msgid "label_news_external_url"
+msgstr "Externer Link für Mobile-Apps"
+
 #. Default: "Show on home page"
 #: ./ftw/news/behaviors/show_on_homepage/news.py:17
 msgid "label_show_on_homepage"
 msgstr "Auf Startseite anzeigen"
 
 #. Default: "Mopage trigger enabled"
-#: ./ftw/news/behaviors/mopage.py:31
+#: ./ftw/news/behaviors/mopage.py:35
 msgid "label_trigger_enabled"
 msgstr "Mopage Trigger aktiviert"
 
@@ -156,7 +169,7 @@ msgid "mark news items to show up on home page"
 msgstr "News-Einträge für Anzeige auf Startseite markieren"
 
 #. Default: "More News"
-#: ./ftw/news/browser/news_listing_block.py:35
+#: ./ftw/news/browser/news_listing_block.py:36
 #: ./ftw/news/browser/templates/news_listing_block.pt:48
 #: ./ftw/news/portlets/templates/news_portlet.pt:37
 msgid "more_news_link_label"
@@ -354,6 +367,7 @@ msgid "rss_link_title"
 msgstr "RSS abonnieren"
 
 #. Default: "News"
-#: ./ftw/news/contents/news_folder.py:33
+#: ./ftw/news/contents/news_folder.py:31
 msgid "title_default_newslisting_block"
 msgstr "News"
+

--- a/ftw/news/locales/ftw.news.pot
+++ b/ftw/news/locales/ftw.news.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-09-19 12:57+0000\n"
+"POT-Creation-Date: 2017-01-11 08:29+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -30,6 +30,10 @@ msgstr ""
 msgid "Display the contents of a news folder."
 msgstr ""
 
+#: ./ftw/news/behaviors/configure.zcml:40
+msgid "External URL (for mobile app)"
+msgstr ""
+
 #: ./ftw/news/configure.zcml:38
 msgid "Installs a feature allowing to mark news to show on homepage."
 msgstr ""
@@ -42,7 +46,7 @@ msgstr ""
 msgid "Mark news listing block to render news on homepage"
 msgstr ""
 
-#: ./ftw/news/behaviors/mopage.py:23
+#: ./ftw/news/behaviors/mopage.py:27
 msgid "Mopage"
 msgstr ""
 
@@ -78,6 +82,10 @@ msgstr ""
 msgid "No content available"
 msgstr ""
 
+#: ./ftw/news/behaviors/configure.zcml:40
+msgid "Provides an additional URL field for mobile apps"
+msgstr ""
+
 #: ./ftw/news/behaviors/configure.zcml:33
 msgid "Provides fields for configuring a mopage trigger (ftw.publisher)."
 msgstr ""
@@ -95,12 +103,12 @@ msgid "The news listing block renders a configurable list of news entries."
 msgstr ""
 
 #. Default: "The mopage data endpoint URL points to the \"mopage.news.xml\" view somewhere on the public visible  Plone page. It must also contain the params \"partnerid\" and \"importid\". Example: https://mypage.ch/news/mopage.news.xml?partnerid=3&importid=6"
-#: ./ftw/news/behaviors/mopage.py:59
+#: ./ftw/news/behaviors/mopage.py:63
 msgid "description_mopage_data_endpoint_url"
 msgstr ""
 
 #. Default: "Contains the mopage URL to the trigger endpoint. This is only the base URL, it does not contain the endpoint URL from which the mopage server retrieves the news. Example: https://un:pw@xml.mopage.ch/infoservice/xml.php"
-#: ./ftw/news/behaviors/mopage.py:42
+#: ./ftw/news/behaviors/mopage.py:46
 msgid "description_mopage_trigger_url"
 msgstr ""
 
@@ -128,12 +136,12 @@ msgid "label_feed_desc"
 msgstr ""
 
 #. Default: "Mopage data endpoint URL (Plone)"
-#: ./ftw/news/behaviors/mopage.py:57
+#: ./ftw/news/behaviors/mopage.py:61
 msgid "label_mopage_data_endpoint_url"
 msgstr ""
 
 #. Default: "Mopage trigger URL"
-#: ./ftw/news/behaviors/mopage.py:40
+#: ./ftw/news/behaviors/mopage.py:44
 msgid "label_mopage_trigger_url"
 msgstr ""
 
@@ -142,13 +150,18 @@ msgstr ""
 msgid "label_more_news_link_label"
 msgstr ""
 
+#. Default: "External link for mobile app"
+#: ./ftw/news/behaviors/external_url.py:14
+msgid "label_news_external_url"
+msgstr ""
+
 #. Default: "Show on home page"
 #: ./ftw/news/behaviors/show_on_homepage/news.py:17
 msgid "label_show_on_homepage"
 msgstr ""
 
 #. Default: "Mopage trigger enabled"
-#: ./ftw/news/behaviors/mopage.py:31
+#: ./ftw/news/behaviors/mopage.py:35
 msgid "label_trigger_enabled"
 msgstr ""
 
@@ -156,7 +169,7 @@ msgid "mark news items to show up on home page"
 msgstr ""
 
 #. Default: "More News"
-#: ./ftw/news/browser/news_listing_block.py:35
+#: ./ftw/news/browser/news_listing_block.py:36
 #: ./ftw/news/browser/templates/news_listing_block.pt:48
 #: ./ftw/news/portlets/templates/news_portlet.pt:37
 msgid "more_news_link_label"
@@ -354,7 +367,7 @@ msgid "rss_link_title"
 msgstr ""
 
 #. Default: "News"
-#: ./ftw/news/contents/news_folder.py:33
+#: ./ftw/news/contents/news_folder.py:31
 msgid "title_default_newslisting_block"
 msgstr ""
 

--- a/ftw/news/permissions.zcml
+++ b/ftw/news/permissions.zcml
@@ -27,4 +27,9 @@
         title="ftw.news: Configure mopage trigger"
         />
 
+    <permission
+        id="ftw.news.EditNewsExternalUrl"
+        title="ftw.news: Edit news external url"
+        />
+
 </configure>

--- a/ftw/news/profiles/default/rolemap.xml
+++ b/ftw/news/profiles/default/rolemap.xml
@@ -25,5 +25,10 @@
             <role name="Site Administrator"/>
         </permission>
 
+        <permission name="ftw.news: Edit news external url" acquire="False">
+            <role name="Manager"/>
+            <role name="Site Administrator"/>
+        </permission>
+
     </permissions>
 </rolemap>

--- a/ftw/news/upgrades/20170110173023_add_new_permission_for_the_mopage_external_url/rolemap.xml
+++ b/ftw/news/upgrades/20170110173023_add_new_permission_for_the_mopage_external_url/rolemap.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+<rolemap>
+    <permissions>
+
+        <permission name="ftw.news: Edit news external url" acquire="False">
+            <role name="Manager"/>
+            <role name="Site Administrator"/>
+        </permission>
+
+    </permissions>
+</rolemap>

--- a/ftw/news/upgrades/20170110173023_add_new_permission_for_the_mopage_external_url/upgrade.py
+++ b/ftw/news/upgrades/20170110173023_add_new_permission_for_the_mopage_external_url/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class AddNewPermissionForTheMopageExternalUrl(UpgradeStep):
+    """Add new permission for the mopage external url.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()


### PR DESCRIPTION
This adds a new field which can be used to override the url of the news item (only used in mobile apps AKA "moPage").