### PR TITLE
Exclude file listings and galleries from mopage endpoint

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.6.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Mopage: exclude file listings and galleries. [jone]
 
 
 1.6.0 (2017-01-16)

--- a/ftw/news/browser/mopage.py
+++ b/ftw/news/browser/mopage.py
@@ -1,6 +1,8 @@
 from DateTime import DateTime
 from ftw.news.behaviors.external_url import INewsExternalUrl
 from ftw.news.behaviors.mopage import IMopageModificationDate
+from ftw.simplelayout.browser.provider import SimplelayoutRenderer
+from ftw.simplelayout.interfaces import IPageConfiguration
 from htmlentitydefs import name2codepoint as n2cp
 from plone.app.dexterity.behaviors.metadata import ICategorization
 from plone.uuid.interfaces import IUUID
@@ -71,6 +73,49 @@ def decode_entities(text):
                 return match.group()
 
     return entity_re.subn(substitute_entity, text)[0]
+
+
+class NewsMopageRenderer(SimplelayoutRenderer):
+
+    def __init__(self, news, view):
+        page_config = IPageConfiguration(news).load()
+        super(NewsMopageRenderer, self).__init__(
+            news, page_config, 'default', view=view)
+
+    def __call__(self):
+        """We have HTML with simplelayout structure, but this is too noisy
+        for the import.
+        We therefore convert the HTML to text and back to HTML.
+        We also need to make sure that the result is less than 10000 long.
+        """
+        html = self.render_slot().strip()
+
+        doc = lxml.html.fromstring(html)
+        map(remove_node, doc.xpath(
+            '//*[contains(concat(" ", normalize-space(@class), " "), '
+            '" hiddenStructure ")]'))
+        html = lxml.etree.tostring(doc, pretty_print=True)
+
+        portal_transforms = getToolByName(self.context, 'portal_transforms')
+        text = decode_entities(portal_transforms.convertToData(
+            'text/x-web-intelligent',
+            html,
+            mimetype='text/html').strip())
+
+        # body limit is 10000.
+        # We have text here, but will convert it to HTML, so it will be larger
+        # and we need to crop more to compensate.
+        for attempt in range(100):
+            text = crop(10000 - (len(text) * 0.1), text)
+            html = portal_transforms.convertToData(
+                'text/html',
+                text,
+                mimetype='text/x-web-intelligent').strip()
+
+            if len(html) < 10000:
+                return ('<![CDATA[' + html + ']]>').decode('utf-8')
+
+        return u'<![CDATA[cropping error]]>'
 
 
 class MopageNews(BrowserView):
@@ -152,7 +197,8 @@ class MopageNews(BrowserView):
                 'textlead': textlead,
                 'image_url': image_url,
                 'subjects': map(lambda subject: crop(100, subject), subjects),
-                'obj': obj}
+                'obj': obj,
+                'html': NewsMopageRenderer(obj, self)()}
 
     def normalize_date(self, date):
         if not date:
@@ -162,40 +208,6 @@ class MopageNews(BrowserView):
             return None
 
         return date.strftime('%Y-%m-%d %H:%M:%S')
-
-    def cleanup_body_html(self, html):
-        """We have HTML with simplelayout structure, but this is too noisy
-        for the import.
-        We therefore convert the HTML to text and back to HTML.
-        We also need to make sure that the result is less than 10000 long.
-        """
-
-        doc = lxml.html.fromstring(html)
-        map(remove_node, doc.xpath(
-            '//*[contains(concat(" ", normalize-space(@class), " "), '
-            '" hiddenStructure ")]'))
-        html = lxml.etree.tostring(doc, pretty_print=True)
-
-        portal_transforms = getToolByName(self.context, 'portal_transforms')
-        text = decode_entities(portal_transforms.convertToData(
-            'text/x-web-intelligent',
-            html,
-            mimetype='text/html').strip())
-
-        # body limit is 10000.
-        # We have text here, but will convert it to HTML, so it will be larger
-        # and we need to crop more to compensate.
-        for attempt in range(100):
-            text = crop(10000 - (len(text) * 0.1), text)
-            html = portal_transforms.convertToData(
-                'text/html',
-                text,
-                mimetype='text/x-web-intelligent').strip()
-
-            if len(html) < 10000:
-                return ('<![CDATA[' + html + ']]>').decode('utf-8')
-
-        return u'<![CDATA[cropping error]]>'
 
     def get_lead_image_url(self, news):
         scale = news.restrictedTraverse('@@leadimage').get_scale()

--- a/ftw/news/browser/mopage.py
+++ b/ftw/news/browser/mopage.py
@@ -2,6 +2,8 @@ from DateTime import DateTime
 from ftw.news.behaviors.external_url import INewsExternalUrl
 from ftw.news.behaviors.mopage import IMopageModificationDate
 from ftw.simplelayout.browser.provider import SimplelayoutRenderer
+from ftw.simplelayout.contenttypes.contents.interfaces import IFileListingBlock
+from ftw.simplelayout.contenttypes.contents.interfaces import IGalleryBlock
 from ftw.simplelayout.interfaces import IPageConfiguration
 from htmlentitydefs import name2codepoint as n2cp
 from plone.app.dexterity.behaviors.metadata import ICategorization
@@ -116,6 +118,13 @@ class NewsMopageRenderer(SimplelayoutRenderer):
                 return ('<![CDATA[' + html + ']]>').decode('utf-8')
 
         return u'<![CDATA[cropping error]]>'
+
+    def _blocks(self):
+        # Exclude listing blocks and galleries.
+        blocks = super(NewsMopageRenderer, self)._blocks()
+        return {uid: block for uid, block in blocks.items()
+                if not IFileListingBlock.providedBy(block)
+                and not IGalleryBlock.providedBy(block)}
 
 
 class MopageNews(BrowserView):

--- a/ftw/news/browser/templates/mopage_news.pt
+++ b/ftw/news/browser/templates/mopage_news.pt
@@ -21,9 +21,8 @@
         <textlead tal:content="structure item/textlead" />
         <web_url tal:condition="item/web_url" tal:content="item/web_url" />
         <url_bild tal:content="item/image_url" tal:condition="item/image_url" />
-        <textmobile tal:define="context nocall:item/obj;
-                                html simplelayout:default">
-            <tal:TEXT replace="structure python:view.cleanup_body_html(html)" />
+        <textmobile>
+            <tal:TEXT content="structure item/html" />
         </textmobile>
         <rubrik tal:repeat="subject item/subjects"
                 tal:content="subject" />

--- a/ftw/news/tests/test_mopage.py
+++ b/ftw/news/tests/test_mopage.py
@@ -49,6 +49,14 @@ class TestMopageExport(FunctionalTestCase, XMLDiffTestCase):
                    .having(news_date=datetime(2010, 5, 18, 12, 00),
                            expires=datetime(2020, 1, 1)))
 
+        # listing block should not appear in endpoint
+        listingblock = create(Builder('sl listingblock')
+                              .titled('My listingblock')
+                              .having(show_title=True)
+                              .within(news1))
+
+        create(Builder('file').with_dummy_content().within(listingblock))
+
         with freeze(datetime(2011, 1, 2, 3, 4)):
             self.assert_mopage_export('01_export_news.xml', news_folder)
 

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ extras_require = {
         'collective.taskqueue',
         'ftw.publisher.receiver',
         'requests',
+        'ftw.simplelayout >= 1.15.0',
     ],
 }
 


### PR DESCRIPTION
As the mopage endpoint currently is text-only, it does not make sense to include galleries and file listings. Therefore those are removed.

In order to do that nicely I've changed the rendering to use the new simplelayout renderer instead of rendering in the template.