### PR TITLE
Make RSS views compatible with "ftw.contentpage".

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,9 @@ Changelog
 1.6.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Add RSS views which are backwards compatible with ftw.contentpage
+  (requires a custom browser layer for ftw.news).
+  [mbaechtold]
 
 
 1.6.1 (2017-01-17)

--- a/ftw/news/browser/configure.zcml
+++ b/ftw/news/browser/configure.zcml
@@ -32,12 +32,32 @@
         permission="zope2.View"
         />
 
+    <!-- Same as above but for backward compatibility with ftw.contentpage -->
+    <browser:page
+        for="ftw.news.interfaces.INewsListingBlock"
+        name="news_rss_listing"
+        class=".news_listing.NewsListingRssOfNewsListingBlock"
+        template="./templates/news_listing_rss.pt"
+        permission="zope2.View"
+        layer="ftw.news.interfaces.IFtwNewsLayer"
+        />
+
     <browser:page
         for="*"
         name="news_listing_rss"
         class=".news_listing.NewsListingRss"
         template="./templates/news_listing_rss.pt"
         permission="zope2.View"
+        />
+
+    <!-- Same as above but for backward compatibility with ftw.contentpage -->
+    <browser:page
+        for="*"
+        name="news_rss_listing"
+        class=".news_listing.NewsListingRss"
+        template="./templates/news_listing_rss.pt"
+        permission="zope2.View"
+        layer="ftw.news.interfaces.IFtwNewsLayer"
         />
 
     <browser:page

--- a/ftw/news/interfaces.py
+++ b/ftw/news/interfaces.py
@@ -5,6 +5,10 @@
 from zope.interface import Interface
 
 
+class IFtwNewsLayer(Interface):
+    """Request layer for ftw.news"""
+
+
 class INewsFolder(Interface):
     """Marker interface for the news folder"""
 

--- a/ftw/news/profiles/default/browserlayer.xml
+++ b/ftw/news/profiles/default/browserlayer.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<layers>
+
+    <layer name="ftw.news"
+           interface="ftw.news.interfaces.IFtwNewsLayer" />
+
+</layers>

--- a/ftw/news/tests/test_news_listing_rss.py
+++ b/ftw/news/tests/test_news_listing_rss.py
@@ -26,11 +26,15 @@ class TestNewsRssListing(FunctionalTestCase):
 
         view = news_folder.unrestrictedTraverse('news_listing_rss')
         view.max_items = 200
-
         self.assertEqual(2, len(view.get_items()))
-
         view.max_items = 1
+        self.assertEqual(1, len(view.get_items()))
 
+        # Same test but with the view from "ftw.contentpage" for backward compatibility.
+        view = news_folder.unrestrictedTraverse('news_rss_listing')
+        view.max_items = 200
+        self.assertEqual(2, len(view.get_items()))
+        view.max_items = 1
         self.assertEqual(1, len(view.get_items()))
 
     @browsing
@@ -38,6 +42,15 @@ class TestNewsRssListing(FunctionalTestCase):
         news_folder = create(Builder('news folder'))
 
         browser.login().visit(news_folder, view='news_listing_rss')
+
+        self.assertIn(
+            '<link>{0}</link>'.format(news_folder.absolute_url()),
+            browser.contents,
+            'Did not found the link tag of the channel'
+        )
+
+        # Same test but with the view from "ftw.contentpage" for backward compatibility.
+        browser.login().visit(news_folder, view='news_rss_listing')
 
         self.assertIn(
             '<link>{0}</link>'.format(news_folder.absolute_url()),
@@ -63,6 +76,17 @@ class TestNewsRssListing(FunctionalTestCase):
         self.assertIn(link, browser.contents,
                       'Did not found the link tag for the news')
 
+        # Same test but with the view from "ftw.contentpage" for backward compatibility.
+        browser.login().visit(news_folder, view='news_rss_listing')
+
+        rdf = '<rdf:li rdf:resource="{0}"'.format(news.absolute_url())
+        self.assertIn(rdf, browser.contents,
+                      'Did not found the rdf tag for the news')
+
+        link = '<link>{0}</link>'.format(news.absolute_url())
+        self.assertIn(link, browser.contents,
+                      'Did not found the link tag for the news')
+
     @browsing
     def test_news_item_contains_pubdate(self, browser):
         news_folder = create(Builder('news folder'))
@@ -72,6 +96,21 @@ class TestNewsRssListing(FunctionalTestCase):
                       .having(news_date=datetime(2000, 12, 31, 15, 0, 0)))
 
         browser.login().visit(news_folder, view='news_listing_rss')
+
+        # Use HTML parser so that we have no XML namespaces.
+        browser.parse_as_html()
+
+        self.assertEqual(
+            # Difference between "%e" and "%-e":
+            # %e has a leading space on single numbers - that's why the tests
+            # were failing between the 1st and the 9th every month :-)
+            # %-e Removes the leading space - only works on unix machines.
+            news.news_date.strftime('%a, %-e %b %Y %H:%M:%S %z').strip(),
+            browser.css('rdf item pubDate').first.text
+        )
+
+        # Same test but with the view from "ftw.contentpage" for backward compatibility.
+        browser.login().visit(news_folder, view='news_rss_listing')
 
         # Use HTML parser so that we have no XML namespaces.
         browser.parse_as_html()

--- a/ftw/news/upgrades/20170123164618_install_browser_layer_for_ftw_news/browserlayer.xml
+++ b/ftw/news/upgrades/20170123164618_install_browser_layer_for_ftw_news/browserlayer.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<layers>
+
+    <layer name="ftw.news"
+           interface="ftw.news.interfaces.IFtwNewsLayer" />
+
+</layers>

--- a/ftw/news/upgrades/20170123164618_install_browser_layer_for_ftw_news/upgrade.py
+++ b/ftw/news/upgrades/20170123164618_install_browser_layer_for_ftw_news/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class InstallBrowserLayerForFtwNews(UpgradeStep):
+    """Install browser layer for "ftw.news".
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()


### PR DESCRIPTION
This solves the use case where users have subscribed to RSS feeds from "ftw.contentpage"; these urls would no longer work after having migrated to "ftw.news" because they do not have the same name.

The solution is to provide the same views under the old names.