### PR TITLE
Unify portlet markup

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,12 @@ Changelog
 1.6.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Unify news- and archive portlet markup
+
+  - Use porlet class for wrapper on news-portlet.
+  - Use header for title and section for body.
+
+  [Kevin Bieri]
 
 
 1.6.2 (2017-01-24)

--- a/ftw/news/browser/resources/archive.scss
+++ b/ftw/news/browser/resources/archive.scss
@@ -3,6 +3,10 @@
     @include list-tree($indentation: $line-height-base);
   }
 
+  .count {
+    @include label-round();
+  }
+
   .year {
     @extend .fa-icon;
     @extend .fa-angle-right;
@@ -15,21 +19,9 @@
         display: block;
       }
     }
-
-    .count {
-      @include label-round();
-    }
   }
 
   .months {
     display: none;
-    .count {
-      &:before {
-        content: "(";
-      }
-      &:after {
-        content: ")";
-      }
-    }
   }
 }

--- a/ftw/news/browser/resources/news.scss
+++ b/ftw/news/browser/resources/news.scss
@@ -9,7 +9,6 @@ $leadimage-max-width: 200px !default;
 
 .news-row {
   @include list();
-  margin-bottom: $margin-vertical;
 
   > li:last-child .news-item {
     margin-bottom: 0;

--- a/ftw/news/portlets/templates/news_archive_portlet.pt
+++ b/ftw/news/portlets/templates/news_archive_portlet.pt
@@ -3,41 +3,42 @@
       tal:omit-tag="python: 1"
       i18n:domain="ftw.news">
 
-    <section class="archive-portlet">
+    <section class="portlet archive-portlet">
 
-        <header>
+        <header class="portletHeader">
             <h2 i18n:translate="">Archive</h2>
         </header>
+        <section class="portletItem">
+          <ul class="years">
+              <li tal:repeat="year view/get_items">
 
-        <ul class="years">
-            <li tal:repeat="year view/get_items">
+                  <a href="#"
+                     tal:attributes="class year/class;
+                                     aria-controls string:year_${year/title}"
+                     aria-haspopup="true">
+                     <span class="title" tal:content="year/title"></span>
+                     <span class="count"
+                           tal:content="year/count"
+                           tal:condition="year/count"></span>
+                  </a>
 
-                <a href="#"
-                   tal:attributes="class year/class;
-                                   aria-controls string:year_${year/title}"
-                   aria-haspopup="true">
-                   <span class="title" tal:content="year/title"></span>
-                   <span class="count"
-                         tal:content="year/count"
-                         tal:condition="year/count"></span>
-                </a>
-
-                <ul tal:attributes="class year/months_expanded;
-                                    id string:year_${year/title}"
-                    aria-hidden="true">
-                    <li tal:repeat="month year/months">
-                        <a tal:attributes="href month/url;
-                                           title month/title;
-                                           class month/class"
-                           i18n:translate="">
-                           <span class="title" tal:content="month/title"></span>
-                           <span class="count"
-                                 tal:content="month/count"
-                                 tal:condition="month/count"></span>
-                        </a>
-                    </li>
-                </ul>
-            </li>
-        </ul>
+                  <ul tal:attributes="class year/months_expanded;
+                                      id string:year_${year/title}"
+                      aria-hidden="true">
+                      <li tal:repeat="month year/months">
+                          <a tal:attributes="href month/url;
+                                             title month/title;
+                                             class month/class"
+                             i18n:translate="">
+                             <span class="title" tal:content="month/title"></span>
+                             <span class="count"
+                                   tal:content="month/count"
+                                   tal:condition="month/count"></span>
+                          </a>
+                      </li>
+                  </ul>
+              </li>
+          </ul>
+        </section>
     </section>
 </html>

--- a/ftw/news/portlets/templates/news_portlet.pt
+++ b/ftw/news/portlets/templates/news_portlet.pt
@@ -6,31 +6,33 @@
     <section class="portlet news-portlet"
         tal:define="items view/get_items;">
 
-        <header>
+        <header class="portletHeader">
             <h2 tal:content="view/data/news_listing_config_title"></h2>
         </header>
-        <ul class="news-row">
-            <li class="portletItem noRecentNews"
-                tal:condition="not: items"
-                i18n:translate="no_recent_news_label">No recent news available.</li>
+        <section class="portletItem">
+          <ul class="news-row">
+              <li class="portletItem noRecentNews"
+                  tal:condition="not: items"
+                  i18n:translate="no_recent_news_label">No recent news available.</li>
 
-            <tal:loop tal:repeat="item items">
-                <li>
-                    <a class="news-item" tal:attributes="href item/url">
-                        <div tal:condition="item/image_tag"
-                             tal:content="structure item/image_tag"
-                             class="image">
-                        </div>
-                        <div tal:attributes="class python:'body show-image' if view.data.show_lead_image else 'body'">
-                          <span class="byline" tal:content="item/news_date" />
-                          <h3 class="title" tal:content="item/title" />
-                          <span class="description" tal:content="item/description" tal:condition="item/description"/>
-                        </div>
-                    </a>
-                </li>
-            </tal:loop>
+              <tal:loop tal:repeat="item items">
+                  <li>
+                      <a class="news-item" tal:attributes="href item/url">
+                          <div tal:condition="item/image_tag"
+                               tal:content="structure item/image_tag"
+                               class="image">
+                          </div>
+                          <div tal:attributes="class python:'body show-image' if view.data.show_lead_image else 'body'">
+                            <span class="byline" tal:content="item/news_date" />
+                            <h3 class="title" tal:content="item/title" />
+                            <span class="description" tal:content="item/description" tal:condition="item/description"/>
+                          </div>
+                      </a>
+                  </li>
+              </tal:loop>
 
-        </ul>
+          </ul>
+        </section>
         <tal:footer tal:define="more_news_url view/more_news_url;
                                 show_rss_link view/show_rss_link">
             <footer tal:condition="python: more_news_url or show_rss_link">


### PR DESCRIPTION
Unify news- and archive portlet markup:

- Use `porlet` class for wrapper on news-portlet.
- Use `header` for title and `section` for body.

![screen shot 2017-01-26 at 10 22 05](https://cloud.githubusercontent.com/assets/1637820/22325999/4f4704ec-e3b1-11e6-85fa-bb7a755f6336.png)

Display badge instead for month count instead of a number wrapped in parentheses.
![screen shot 2017-01-26 at 10 21 58](https://cloud.githubusercontent.com/assets/1637820/22326000/4f4dd29a-e3b1-11e6-89e9-bd830fdae8d2.png)
