### PR TITLE
Make news linkable in tinymce editor

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 1.6.3 (unreleased)
 ------------------
 
+- Make News and NewsFolder linkable in TinyMCE
+  [raphael-s]
+
 - Unify news- and archive portlet markup
 
   - Use porlet class for wrapper on news-portlet.

--- a/ftw/news/profiles/default/tinymce.xml
+++ b/ftw/news/profiles/default/tinymce.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<object>
+    <resourcetypes>
+        <linkable purge="False">
+            <element value="ftw.news.NewsFolder"/>
+            <element value="ftw.news.News"/>
+        </linkable>
+    </resourcetypes>
+</object>


### PR DESCRIPTION
Contents of the type `News` or `NewsFolder` can now be linked in the TinyMCE editor.

No upgrade step, because it could change configuration of existing projects.

closes #86 