### PR TITLE
Fix news mopage template.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,8 @@ Changelog
 1.6.3 (unreleased)
 ------------------
 
+- Fix news mopage template. [mbaechtold]
+
 - Use "ftw.keywordwidget" as the widget used to enter subjects/keywords.
   You may need to install "select2" manually. See the README for more
   information. [mbaechtold]

--- a/ftw/news/browser/mopage.py
+++ b/ftw/news/browser/mopage.py
@@ -202,7 +202,7 @@ class MopageNews(BrowserView):
                 'expires': self.normalize_date(brain.expires),
                 'modified_date': self.normalize_date(modified_date),
                 'uid': IUUID(obj),
-                'web_url': getattr(INewsExternalUrl(obj, None), 'external_url', ''),
+                'external_url': getattr(INewsExternalUrl(obj, None), 'external_url', ''),
                 'textlead': textlead,
                 'image_url': image_url,
                 'subjects': map(lambda subject: crop(100, subject), subjects),

--- a/ftw/news/browser/templates/mopage_news.pt
+++ b/ftw/news/browser/templates/mopage_news.pt
@@ -19,7 +19,7 @@
         <id tal:content="item/uid" />
         <titel tal:content="item/title" />
         <textlead tal:content="structure item/textlead" />
-        <web_url tal:condition="item/web_url" tal:content="item/web_url" />
+        <url_web tal:condition="item/external_url" tal:content="item/external_url" />
         <url_bild tal:content="item/image_url" tal:condition="item/image_url" />
         <textmobile>
             <tal:TEXT content="structure item/html" />

--- a/ftw/news/tests/test_mopage.py
+++ b/ftw/news/tests/test_mopage.py
@@ -191,5 +191,5 @@ class TestMopageExport(FunctionalTestCase, XMLDiffTestCase):
         browser.open(self.portal, view='mopage.news.xml')
         self.assertEqual(
             ['http://www.4teamwork.ch/'],
-            browser.css('web_url').text
+            browser.css('url_web').text
         )


### PR DESCRIPTION
The node for the external url has been misspelled when the feature has been implemented in https://github.com/4teamwork/ftw.news/pull/82