### PR TITLE
Fix a bug where the news portlet was shown incorrectly.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 1.7.1 (unreleased)
 ------------------
 
+- Fix a bug where the news portlet was shown when it shouldn't have
+  been shown. [mbaechtold]
+
 - Include inactive news items in the listing view and the news portlet
   if the user has the permission to add news items. [mbaechtold]
 

--- a/ftw/news/portlets/news_portlet.py
+++ b/ftw/news/portlets/news_portlet.py
@@ -117,12 +117,7 @@ class Renderer(base.Renderer):
         if INewsFolder.providedBy(self.data):
             return False
 
-        if self.data.show_more_news_link:
-            has_news = self.get_news(all_news=True)
-        else:
-            has_news = self.get_news()
-
-        return has_news
+        return bool(self.get_news())
 
     def get_query(self, all_news):
         url_tool = getToolByName(self.context, 'portal_url')

--- a/ftw/news/tests/builders.py
+++ b/ftw/news/tests/builders.py
@@ -1,5 +1,7 @@
 from ftw.builder import builder_registry
 from ftw.builder.dexterity import DexterityBuilder
+from ftw.builder.portlets import PlonePortletBuilder
+from ftw.news.portlets import news_portlet
 from ftw.simplelayout.tests import builders
 from ftw.subsite.tests import builders
 
@@ -24,3 +26,10 @@ class NewsListingBlockBuilder(DexterityBuilder):
         return self
 
 builder_registry.register('news listing block', NewsListingBlockBuilder)
+
+
+class NewsPortletBuilder(PlonePortletBuilder):
+    manager_name = u'plone.rightcolumn'
+    assignment_class = news_portlet.Assignment
+
+builder_registry.register('news portlet', NewsPortletBuilder)


### PR DESCRIPTION
Until now the portlet was rendered incorrectly when the portlet was configured to show a link to the news listing view but did not have any news items to be rendered. But the portlet must not be rendered when it does not have any news.