### PR TITLE
Make NewsFolder and NewsListingBlock addable on plone site

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.8.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Make NewsFolder and NewsListingBlock addable on plone site per default [raphael-s]
 
 
 1.8.0 (2017-02-28)

--- a/ftw/news/profiles/default/types/Plone_Site.xml
+++ b/ftw/news/profiles/default/types/Plone_Site.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<object name="Plone Site">
+
+    <property name="allowed_content_types" purge="False">
+        <element value="ftw.news.NewsFolder" />
+        <element value="ftw.news.NewsListingBlock" />
+    </property>
+
+</object>


### PR DESCRIPTION
When `ftw.news` is installed NewsFolder and NewsListingBlock can now be added to plone site per default.

We don't want an upgrade step for this because we don't want to change how existing deployments handle those two content types.