### PR TITLE
Fix rendering of inactive news.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.8.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix a bug which prevented inactive news from being shown in combination
+  with Solr. [mbaechtold]
 
 
 1.8.2 (2017-03-13)

--- a/ftw/news/browser/news_listing_block.py
+++ b/ftw/news/browser/news_listing_block.py
@@ -53,7 +53,7 @@ class NewsListingBlockView(BaseBlock):
         catalog = getToolByName(self.context, 'portal_catalog')
 
         brains = catalog.searchResults(
-            self.get_query()
+            **self.get_query()
         )
 
         if self.context.quantity:


### PR DESCRIPTION
This has only been noticed once it has been installed on the production server where Solr is installed (Solr is not installed in the tests).