### PR TITLE
Fix timestamps in tests.

### DIFF
--- a/ftw/news/tests/mopage_assets/01_export_news.xml
+++ b/ftw/news/tests/mopage_assets/01_export_news.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="iso-8859-15" ?>
 <import export_time="2011-01-02 03:04:00">
 
-    <item status="1" suchbar="1" mutationsdatum="2010-05-17 16:34:00" datumvon="2010-05-18 12:00:00" datumbis="2020-01-01 00:00:00">
+    <item status="1" suchbar="1" mutationsdatum="2010-05-17 15:34:00" datumvon="2010-05-18 12:00:00" datumbis="2020-01-01 00:00:00">
         <id>uid00000000000000000000000000005</id>
         <titel>Largest Aircraft in the World</titel>
         <textlead></textlead>

--- a/ftw/news/tests/test_mopage.py
+++ b/ftw/news/tests/test_mopage.py
@@ -139,7 +139,7 @@ class TestMopageExport(FunctionalTestCase, XMLDiffTestCase):
 
         self.assertEquals(
             {
-                'export_time': '2016-08-09 22:45:00',
+                'export_time': '2016-08-09 21:45:00',
                 'partner': 'Partner',
                 'partnerid': '123',
                 'passwort': 's3c>r3t',


### PR DESCRIPTION
Date / time freezing errors were fixed in ftw.testing.
Because of those bugs we had wrong timestamps in our tests.
This fixes the timestamps to be the correct ones.

https://github.com/4teamwork/ftw.testing/pull/30
https://github.com/4teamwork/ftw.testing/pull/29