### PR TITLE
Update news_listing_rss view to RSS version 2.0

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,8 @@ Changelog
 1.9.1 (unreleased)
 ------------------
 
+- Update RSS to version 2.0 in news_listing_rss view [raphael-s]
+
 - Add option to hide emtpy news listing block. [mbaechtold]
 
 - Use "ftw.referencewidget" as the widget for selecting the paths used

--- a/ftw/news/browser/news_listing.py
+++ b/ftw/news/browser/news_listing.py
@@ -1,6 +1,7 @@
 from Acquisition import aq_inner
 from Acquisition import aq_parent
 from DateTime import DateTime
+from DateTime import DateTime
 from ftw.news import _
 from ftw.news import utils
 from ftw.news.interfaces import INewsListingView
@@ -105,6 +106,9 @@ class NewsListing(BrowserView):
 
     def format_date(self, brain):
         return self.context.toLocalizedTime(brain.start, long_format=False)
+
+    def get_rfc822(self, item):
+        return DateTime(item.start).rfc822()
 
 
 class NewsListingRss(NewsListing):

--- a/ftw/news/browser/templates/news_listing_rss.pt
+++ b/ftw/news/browser/templates/news_listing_rss.pt
@@ -1,42 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<rdf:RDF
-    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-    xmlns:dc="http://purl.org/dc/elements/1.1/"
-    xmlns:syn="http://purl.org/rss/1.0/modules/syndication/"
-    xmlns="http://purl.org/rss/1.0/"
-    xmlns:tal="http://xml.zope.org/namespaces/tal"
-    xmlns:metal="http://xml.zope.org/namespaces/metal">
-
-    <tal:block
-        tal:define="items view/get_items">
-
-        <channel rdf:about="" tal:attributes="rdf:about request/URL">
-            <title tal:content="view/title">The title</title>
-            <span tal:replace="structure view/get_channel_link_tag"></span>
-            <description tal:content="view/description" />
-            <image tal:attributes="rdf:resource string:${context/portal_url}/logo.png" />
-            <items>
-                <rdf:Seq>
-                    <tal:batch repeat="lazy_item items">
-                    <tal:block define="item python:view.get_item_dict(lazy_item)">
-                        <rdf:li rdf:resource=""
-                                tal:attributes="rdf:resource item/url" />
-                    </tal:block>
-                    </tal:batch>
-                </rdf:Seq>
-            </items>
-        </channel>
-        <tal:batch repeat="lazy_item items">
-            <tal:block define="item python:view.get_item_dict(lazy_item)">
-            <item rdf:about="" tal:attributes="rdf:about item/url">
-                <title tal:content="item/title" />
-                <span tal:replace="structure item/link_tag"></span>
-                <description tal:content="item/description" />
-                <pubDate tal:content="item/news_date"/>
-            </item>
-            </tal:block>
-        </tal:batch>
-
-    </tal:block>
-
-</rdf:RDF>
+<rss version="2.0"
+     xmlns:tal="http://xml.zope.org/namespaces/tal"
+     xmlns:atom="http://www.w3.org/2005/Atom">
+    <channel tal:define="items view/get_items">
+        <atom:link tal:attributes="href string:${view/context/absolute_url}/${view/__name__}"
+                   rel="self"
+                   type="application/rss+xml" />
+        <title tal:content="view/title" />
+        <link tal:content="view/link" />
+        <description tal:content="view/description" />
+        <item tal:repeat='item items'>
+            <title tal:content="item/Title" />
+            <link tal:content="item/getURL" />
+            <description tal:content="item/Description" />
+            <guid tal:content="item/getURL" />
+            <pubDate tal:define="date python: view.get_rfc822(item)"
+                     tal:condition="date"
+                     tal:content="date" />
+        </item>
+    </channel>
+</rss>

--- a/ftw/news/tests/test_news_listing_rss.py
+++ b/ftw/news/tests/test_news_listing_rss.py
@@ -1,3 +1,4 @@
+from DateTime import DateTime
 from datetime import datetime
 from ftw.builder import Builder
 from ftw.builder import create
@@ -44,18 +45,20 @@ class TestNewsRssListing(FunctionalTestCase):
         browser.login().visit(news_folder, view='news_listing_rss')
 
         self.assertIn(
-            '<link>{0}</link>'.format(news_folder.absolute_url()),
+            '<link>{url}/{view}</link>'.format(url=news_folder.absolute_url(),
+                                               view='news_listing_rss'),
             browser.contents,
-            'Did not found the link tag of the channel'
+            'Could not find the link tag of the channel'
         )
 
         # Same test but with the view from "ftw.contentpage" for backward compatibility.
         browser.login().visit(news_folder, view='news_rss_listing')
 
         self.assertIn(
-            '<link>{0}</link>'.format(news_folder.absolute_url()),
+            '<link>{url}/{view}</link>'.format(url=news_folder.absolute_url(),
+                                               view='news_rss_listing'),
             browser.contents,
-            'Did not found the link tag of the channel'
+            'Could not find the link tag of the channel'
         )
 
     @browsing
@@ -68,24 +71,24 @@ class TestNewsRssListing(FunctionalTestCase):
 
         browser.login().visit(news_folder, view='news_listing_rss')
 
-        rdf = '<rdf:li rdf:resource="{0}"'.format(news.absolute_url())
-        self.assertIn(rdf, browser.contents,
-                      'Did not found the rdf tag for the news')
+        rss = '<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">'
+        self.assertIn(rss, browser.contents,
+                      'Could not find the rss tag for the news')
 
         link = '<link>{0}</link>'.format(news.absolute_url())
         self.assertIn(link, browser.contents,
-                      'Did not found the link tag for the news')
+                      'Could not find the link tag for the news')
 
         # Same test but with the view from "ftw.contentpage" for backward compatibility.
         browser.login().visit(news_folder, view='news_rss_listing')
 
-        rdf = '<rdf:li rdf:resource="{0}"'.format(news.absolute_url())
-        self.assertIn(rdf, browser.contents,
-                      'Did not found the rdf tag for the news')
+        rss = '<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">'
+        self.assertIn(rss, browser.contents,
+                      'Could not find the rss tag for the news')
 
         link = '<link>{0}</link>'.format(news.absolute_url())
         self.assertIn(link, browser.contents,
-                      'Did not found the link tag for the news')
+                      'Could not find the link tag for the news')
 
     @browsing
     def test_news_item_contains_pubdate(self, browser):
@@ -105,8 +108,8 @@ class TestNewsRssListing(FunctionalTestCase):
             # %e has a leading space on single numbers - that's why the tests
             # were failing between the 1st and the 9th every month :-)
             # %-e Removes the leading space - only works on unix machines.
-            news.news_date.strftime('%a, %-e %b %Y %H:%M:%S %z').strip(),
-            browser.css('rdf item pubDate').first.text
+            DateTime(news.news_date).rfc822(),
+            browser.css('rss item pubDate').first.text
         )
 
         # Same test but with the view from "ftw.contentpage" for backward compatibility.
@@ -120,8 +123,8 @@ class TestNewsRssListing(FunctionalTestCase):
             # %e has a leading space on single numbers - that's why the tests
             # were failing between the 1st and the 9th every month :-)
             # %-e Removes the leading space - only works on unix machines.
-            news.news_date.strftime('%a, %-e %b %Y %H:%M:%S %z').strip(),
-            browser.css('rdf item pubDate').first.text
+            DateTime(news.news_date).rfc822(),
+            browser.css('rss item pubDate').first.text
         )
 
     @browsing
@@ -150,6 +153,6 @@ class TestNewsRssListing(FunctionalTestCase):
         browser.visit(news_listing_block, view='news_listing_rss')
         browser.parse_as_html()
         self.assertEqual(
-            [u'Ni\xfcs - News Feed'],
-            browser.css('channel description').text
+            u'Ni\xfcs - News Feed',
+            browser.css('channel description').first.text
         )


### PR DESCRIPTION
Updates `news_listing_rss` and `news_rss_listing` view to RSS version 2.0

This was already done in `ftw.contentpage`: https://github.com/4teamwork/ftw.contentpage/pull/245

Since most Plone sites use `ftw.simplelayout`, those changes should (also) be done in `ftw.news`.