### PR TITLE
Add option to hide emtpy news listing block.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.9.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Add option to hide emtpy news listing block. [mbaechtold]
 
 
 1.9.0 (2017-08-08)

--- a/ftw/news/browser/news_listing_block.py
+++ b/ftw/news/browser/news_listing_block.py
@@ -45,6 +45,7 @@ class NewsListingBlockView(BaseBlock):
             'more_news_link_label': more_news_link_label,
             'rss_link_url': rss_link_url or '',
             'show_lead_image': self.context.show_lead_image,
+            'hide_empty_block': self.context.hide_empty_block,
         }
 
         return info

--- a/ftw/news/browser/resources/news.scss
+++ b/ftw/news/browser/resources/news.scss
@@ -113,3 +113,13 @@ $leadimage-max-width: 200px !default;
   }
 }
 
+// Hide empty news listing block for anonymous users.
+.portlet.SimplelayoutPortlet .ftw-news-newslistingblock.hidden {
+  display: none;
+}
+
+// Add special border to empty listing block for authenticated users.
+body.userrole-authenticated .portlet.SimplelayoutPortlet .ftw-news-newslistingblock.hidden {
+  @include boxshadow(0 0 20px 0 $color-warning);
+  display: block;
+}

--- a/ftw/news/browser/templates/news_listing_block.pt
+++ b/ftw/news/browser/templates/news_listing_block.pt
@@ -10,8 +10,11 @@
 
     <tal:news tal:define="news view/get_news;">
 
-        <p tal:condition="not: news"
-           i18n:translate="">No content available</p>
+        <tal:no-items tal:condition="not: news">
+            <p i18n:translate="">No content available</p>
+            <p i18n:translate="hide_empty_block_text"
+               tal:condition="block_info/hide_empty_block">The block is only visible to editors so it can still be edited.</p>
+        </tal:no-items>
 
         <ul class="news-row">
             <li tal:repeat="item news">

--- a/ftw/news/contents/news_listing_block.py
+++ b/ftw/news/contents/news_listing_block.py
@@ -1,9 +1,13 @@
+from Acquisition import aq_inner, aq_parent
 from ftw.news import _
 from ftw.news.contents.common import INewsListingBaseSchema
 from ftw.news.interfaces import INewsListingBlock
+from ftw.simplelayout.contenttypes.behaviors import IHiddenBlock
+from plone import api
 from plone.autoform.interfaces import IFormFieldProvider
 from plone.dexterity.content import Container
 from plone.directives import form
+from plone.uuid.interfaces import IUUID
 from zope import schema
 from zope.interface import alsoProvides
 from zope.interface import implements
@@ -27,11 +31,60 @@ class INewsListingBlockSchema(INewsListingBaseSchema):
     form.order_after(show_title='news_listing_config_title')
     form.order_after(more_news_link_label='show_more_news_link')
 
+    hide_empty_block = schema.Bool(
+        title=_(u'label_hide_empty_block',
+                default=u'Hide empty block'),
+        description=_(u'description_hide_empty_block',
+                      default=u'Hide the block if there are no news items to be shown.'),
+        default=False,
+        required=False,
+    )
+
 alsoProvides(INewsListingBlockSchema, IFormFieldProvider)
 
 
 class NewsListingBlock(Container):
-    implements(INewsListingBlock)
+    implements(INewsListingBlock, IHiddenBlock)
 
     def Title(self):
         return self.news_listing_config_title
+
+    @property
+    def is_hidden(self):
+        if not self.hide_empty_block:
+            return False
+
+        # For unknown reason, `self` is not acquisition wrapped. We
+        # need to get an acquisition wrapped news listing block we
+        # work with.
+        obj = api.content.get(UID=IUUID(self))
+
+        if self.user_can_edit_block(obj):
+            # Editors must always see the block or they cannot edit it anymore.
+            return True
+
+        items = api.content.get_view(
+            name='block_view', context=obj, request=obj.REQUEST
+        ).get_items()
+        return self.hide_empty_block and not items
+
+    @is_hidden.setter
+    def is_hidden(self, value):
+        """
+        This is a dummy setter method in case somebody activates the IHiddenBlock
+        behavior from ftw.simplelayout on the news listing block which makes no
+        sense. It should not be a use case to allow hiding news listing blocks
+        because the block does not really contain the objects, it only displays
+        them from a different location. So if a news listing block ist not desired
+        it should be removed from the content page instead.
+        """
+        raise Exception(
+            'You are not allowed to add the IHiddenBlock behavior on the news listing block.'
+        )
+
+    def user_can_edit_block(self, obj):
+        container = aq_parent(aq_inner(obj))
+        return api.user.has_permission(
+            'Modify portal content',
+            obj=container,
+        )

--- a/ftw/news/locales/de/LC_MESSAGES/ftw.news.po
+++ b/ftw/news/locales/de/LC_MESSAGES/ftw.news.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-01-11 08:29+0000\n"
+"POT-Creation-Date: 2017-09-07 15:39+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -26,7 +26,7 @@ msgstr "Ein Behälter für News-Einträge"
 msgid "Archive"
 msgstr "Archiv"
 
-#: ./ftw/news/browser/configure.zcml:64
+#: ./ftw/news/browser/configure.zcml:84
 msgid "Display the contents of a news folder."
 msgstr ""
 
@@ -62,7 +62,7 @@ msgstr "News-Eintrag"
 msgid "News Folder"
 msgstr "News-Verzeichnis"
 
-#: ./ftw/news/browser/configure.zcml:64
+#: ./ftw/news/browser/configure.zcml:84
 msgid "News listing"
 msgstr "News-Auflistung"
 
@@ -78,7 +78,7 @@ msgstr ""
 msgid "NewsListingBlock"
 msgstr "News-Auflistung"
 
-#: ./ftw/news/browser/templates/news_listing_block.pt:13
+#: ./ftw/news/browser/templates/news_listing_block.pt:14
 msgid "No content available"
 msgstr "Kein Inhalt verfügbar"
 
@@ -94,13 +94,18 @@ msgstr "Felder für die Konfiguration des Mopage Auslösers."
 msgid "RSS"
 msgstr ""
 
-#: ./ftw/news/browser/templates/news_listing_block.pt:54
+#: ./ftw/news/browser/templates/news_listing_block.pt:57
 msgid "Subscribe to the RSS feed"
 msgstr "RSS abonnieren"
 
 #: ./ftw/news/profiles/default/types/ftw.news.NewsListingBlock.xml
 msgid "The news listing block renders a configurable list of news entries."
 msgstr "Der Newsauflistungsblock zeigt eine konfigurierbare Liste von Nachrichten-Meldungen an."
+
+#. Default: "Hide the block if there are no news items to be shown."
+#: ./ftw/news/contents/news_listing_block.py:37
+msgid "description_hide_empty_block"
+msgstr "Der Block wird nicht angezeigt, wenn keine News-Einträge vorhanden sind."
 
 #. Default: "The mopage data endpoint URL points to the \"mopage.news.xml\" view somewhere on the public visible  Plone page. It must also contain the params \"partnerid\" and \"importid\". Example: https://mypage.ch/news/mopage.news.xml?partnerid=3&importid=6"
 #: ./ftw/news/behaviors/mopage.py:63
@@ -113,7 +118,7 @@ msgid "description_mopage_trigger_url"
 msgstr "Die Trigger-URL zeigt auf die Mopage-API. Sie enthält kein \"?url\"-Parameter, dieser wird automatisch angefügt. Beispiel: https://un:pw@xml.mopage.ch/infoservice/xml.php"
 
 #. Default: "This custom label will not be translated."
-#: ./ftw/news/contents/news_listing_block.py:22
+#: ./ftw/news/contents/news_listing_block.py:26
 msgid "description_more_news_link_label"
 msgstr "Dieses Label wird nicht übersetzt."
 
@@ -130,10 +135,20 @@ msgstr "ftw.news"
 msgid "ftw.news (show on homepage feature)"
 msgstr ""
 
+#. Default: "The block is only visible to editors so it can still be edited."
+#: ./ftw/news/browser/templates/news_listing_block.pt:15
+msgid "hide_empty_block_text"
+msgstr "Dieser Block ist nur noch für Benutzer sichtbar, die Inhalte bearbeiten dürfen. So kann der Block weiterhin bearbeitet werden."
+
 #. Default: "${title} - News Feed"
-#: ./ftw/news/browser/news_listing.py:97
+#: ./ftw/news/browser/news_listing.py:102
 msgid "label_feed_desc"
 msgstr "${title} - News Feed"
+
+#. Default: "Hide empty block"
+#: ./ftw/news/contents/news_listing_block.py:35
+msgid "label_hide_empty_block"
+msgstr "Leeren Block ausblenden"
 
 #. Default: "Mopage data endpoint URL (Plone)"
 #: ./ftw/news/behaviors/mopage.py:61
@@ -146,7 +161,7 @@ msgid "label_mopage_trigger_url"
 msgstr "Mopage Trigger URL"
 
 #. Default: "Label for the \"more news\" link"
-#: ./ftw/news/contents/news_listing_block.py:20
+#: ./ftw/news/contents/news_listing_block.py:24
 msgid "label_more_news_link_label"
 msgstr "Label für den Link \"Weitere Einträge\""
 
@@ -169,9 +184,9 @@ msgid "mark news items to show up on home page"
 msgstr "News-Einträge für Anzeige auf Startseite markieren"
 
 #. Default: "More News"
-#: ./ftw/news/browser/news_listing_block.py:36
-#: ./ftw/news/browser/templates/news_listing_block.pt:48
-#: ./ftw/news/portlets/templates/news_portlet.pt:37
+#: ./ftw/news/browser/news_listing_block.py:37
+#: ./ftw/news/browser/templates/news_listing_block.pt:51
+#: ./ftw/news/portlets/templates/news_portlet.pt:39
 msgid "more_news_link_label"
 msgstr "Weitere Einträge"
 
@@ -187,57 +202,57 @@ msgstr "Datum des Eintrages"
 
 #. Default: "by ${author}"
 #: ./ftw/news/browser/templates/news_listing.pt:47
-#: ./ftw/news/browser/templates/news_listing_block.pt:30
+#: ./ftw/news/browser/templates/news_listing_block.pt:33
 msgid "news_listing_author_label"
 msgstr "von ${author}"
 
 #. Default: "Show title"
-#: ./ftw/news/contents/news_listing_block.py:14
+#: ./ftw/news/contents/news_listing_block.py:18
 msgid "news_listing_block_show_title_label"
 msgstr "Titel anzeigen"
 
 #. Default: "You can not filter by path and current context at the same time."
-#: ./ftw/news/contents/common.py:127
+#: ./ftw/news/contents/common.py:125
 msgid "news_listing_config_current_context_and_path_error"
 msgstr "Es nicht möglich, gleichzeitig nach Pfad und aktuellem Bereich zu filtern."
 
 #. Default: "The maximum length of the news item's description. Longer descriptions will be cropped. Enter 0 for no limitation."
-#: ./ftw/news/contents/common.py:78
+#: ./ftw/news/contents/common.py:76
 msgid "news_listing_config_description_length_description"
 msgstr "Maximale Länge der Beschreibung. Längere Beschreibungen werden gekürzt (0 = keine Einschränkung)."
 
 #. Default: "Length of the description"
-#: ./ftw/news/contents/common.py:76
+#: ./ftw/news/contents/common.py:74
 msgid "news_listing_config_description_length_label"
 msgstr "Länge der Beschreibung"
 
 #. Default: "Only show news items from the current context."
-#: ./ftw/news/contents/common.py:42
+#: ./ftw/news/contents/common.py:41
 msgid "news_listing_config_filter_current_context_description"
 msgstr "Nur Einträge aus dem aktuellen Bereich anzeigen."
 
 #. Default: "Limit to current context"
-#: ./ftw/news/contents/common.py:40
+#: ./ftw/news/contents/common.py:39
 msgid "news_listing_config_filter_current_context_label"
 msgstr "Einschränken auf aktuellen Bereich"
 
 #. Default: "Only show news items from a specific path."
-#: ./ftw/news/contents/common.py:27
+#: ./ftw/news/contents/common.py:29
 msgid "news_listing_config_filter_path_description"
 msgstr "Nur Einträge aus einem bestimmten Pfad anzeigen"
 
 #. Default: "Limit to path"
-#: ./ftw/news/contents/common.py:25
+#: ./ftw/news/contents/common.py:27
 msgid "news_listing_config_filter_path_label"
 msgstr "Auf Pfad einschränken"
 
 #. Default: "Only news younger than this value will be rendered. Enter 0 for no limitation."
-#: ./ftw/news/contents/common.py:88
+#: ./ftw/news/contents/common.py:86
 msgid "news_listing_config_maximum_age_description"
 msgstr "Nur neuere Einträge werden angezeigt (0 = keine Einschränkung)."
 
 #. Default: "Maximum age (days)"
-#: ./ftw/news/contents/common.py:86
+#: ./ftw/news/contents/common.py:84
 msgid "news_listing_config_maximum_age_label"
 msgstr "Maximales Alter (in Tagen)"
 
@@ -252,62 +267,62 @@ msgid "news_listing_config_news_on_homepage_label"
 msgstr "Einträge auf Startseite"
 
 #. Default: "The number of news entries to be shown at most. Enter 0 for no limitation."
-#: ./ftw/news/contents/common.py:50
+#: ./ftw/news/contents/common.py:49
 msgid "news_listing_config_quantity_description"
 msgstr "Die maximale Anzahl anzuzeigender Einträge (0 = keine Einschränkung)."
 
 #. Default: "Quantity"
-#: ./ftw/news/contents/common.py:49
+#: ./ftw/news/contents/common.py:48
 msgid "news_listing_config_quantity_label"
 msgstr "Anzahl"
 
 #. Default: "Show the description of the news item"
-#: ./ftw/news/contents/common.py:70
+#: ./ftw/news/contents/common.py:68
 msgid "news_listing_config_show_description_label"
 msgstr "Beschreibung anzeigen"
 
 #. Default: "Renders a lead image (taken from the item's first text block having an image.)"
-#: ./ftw/news/contents/common.py:116
+#: ./ftw/news/contents/common.py:114
 msgid "news_listing_config_show_lead_image_description"
 msgstr "Falls ein Textblock des Eintrages ein Bild hat, wird dieses Bild angezeigt."
 
 #. Default: "Show lead image"
-#: ./ftw/news/contents/common.py:114
+#: ./ftw/news/contents/common.py:112
 msgid "news_listing_config_show_lead_image_label"
 msgstr "Bild anzeigen"
 
 #. Default: "Render a link to a page which renders more news (only if there is at least one news item."
-#: ./ftw/news/contents/common.py:98
+#: ./ftw/news/contents/common.py:96
 msgid "news_listing_config_show_more_news_link_description"
 msgstr "Einen Link zu weiteren Einträgen anzeigen (wird nur angezeigt, wenn es mindestens einen Eintrag gibt)."
 
 #. Default: "Link to more news"
-#: ./ftw/news/contents/common.py:96
+#: ./ftw/news/contents/common.py:94
 msgid "news_listing_config_show_more_news_link_label"
 msgstr "Link zu weiteren Einträgen"
 
 #. Default: "Render a link to the RSS feed of the news."
-#: ./ftw/news/contents/common.py:108
+#: ./ftw/news/contents/common.py:106
 msgid "news_listing_config_show_rss_link_description"
 msgstr "Einen Link zum RSS-Feed der Einträge anzeigen."
 
 #. Default: "Link to RSS feed"
-#: ./ftw/news/contents/common.py:106
+#: ./ftw/news/contents/common.py:104
 msgid "news_listing_config_show_rss_link_label"
 msgstr "Link zum RSS-Feed"
 
 #. Default: "Only news with the selected subjects will be shown."
-#: ./ftw/news/contents/common.py:61
+#: ./ftw/news/contents/common.py:59
 msgid "news_listing_config_subjects_description"
 msgstr "Es werden nur Einträge angezeigt, welche mit diesen Stichworten versehen sind."
 
 #. Default: "Filter by subject"
-#: ./ftw/news/contents/common.py:59
+#: ./ftw/news/contents/common.py:57
 msgid "news_listing_config_subjects_label"
 msgstr "Nach Stichwort filtern"
 
 #. Default: "Title"
-#: ./ftw/news/contents/common.py:17
+#: ./ftw/news/contents/common.py:19
 msgid "news_listing_config_title_label"
 msgstr "Titel"
 
@@ -317,52 +332,52 @@ msgid "news_listing_no_content_text"
 msgstr "Keine Inhalte vorhanden"
 
 #. Default: "This portlet displays news items"
-#: ./ftw/news/portlets/news_portlet.py:34
+#: ./ftw/news/portlets/news_portlet.py:35
 msgid "news_portlet_add_form_description"
 msgstr "Dieses Portlet zeigt News an"
 
 #. Default: "Add News Portlet"
-#: ./ftw/news/portlets/news_portlet.py:33
+#: ./ftw/news/portlets/news_portlet.py:34
 msgid "news_portlet_add_form_label"
 msgstr "News-Portlet hinzufügen"
 
 #. Default: "Render the portlet even if there are no news entries."
-#: ./ftw/news/portlets/news_portlet.py:25
+#: ./ftw/news/portlets/news_portlet.py:26
 msgid "news_portlet_always_render_portlet_description"
 msgstr "Portlet auch anzeigen, wenn keine Einträge vorhanden sind."
 
 #. Default: "Always render the portlet"
-#: ./ftw/news/portlets/news_portlet.py:23
+#: ./ftw/news/portlets/news_portlet.py:24
 msgid "news_portlet_always_render_portlet_label"
 msgstr "Portlet immer anzeigen"
 
 #. Default: "Cancel"
-#: ./ftw/news/portlets/news_portlet.py:255
+#: ./ftw/news/portlets/news_portlet.py:258
 msgid "news_portlet_edit_form_cancel_label"
 msgstr "Abbrechen"
 
 #. Default: "This portlet displays news items"
-#: ./ftw/news/portlets/news_portlet.py:217
+#: ./ftw/news/portlets/news_portlet.py:220
 msgid "news_portlet_edit_form_description"
 msgstr "Dieses Portlet zeigt News an"
 
 #. Default: "Edit News Portlet"
-#: ./ftw/news/portlets/news_portlet.py:216
+#: ./ftw/news/portlets/news_portlet.py:219
 msgid "news_portlet_edit_form_label"
 msgstr "News-Portlet bearbeiten"
 
 #. Default: "Save"
-#: ./ftw/news/portlets/news_portlet.py:238
+#: ./ftw/news/portlets/news_portlet.py:241
 msgid "news_portlet_edit_form_save_label"
 msgstr "Speichern"
 
 #. Default: "No recent news available."
-#: ./ftw/news/portlets/templates/news_portlet.pt:13
+#: ./ftw/news/portlets/templates/news_portlet.pt:14
 msgid "no_recent_news_label"
 msgstr "Keine Einträge vorhanden."
 
 #. Default: "Subscribe to the RSS feed"
-#: ./ftw/news/portlets/templates/news_portlet.pt:43
+#: ./ftw/news/portlets/templates/news_portlet.pt:45
 msgid "rss_link_title"
 msgstr "RSS abonnieren"
 

--- a/ftw/news/locales/ftw.news.pot
+++ b/ftw/news/locales/ftw.news.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-01-11 08:29+0000\n"
+"POT-Creation-Date: 2017-09-07 15:39+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -26,7 +26,7 @@ msgstr ""
 msgid "Archive"
 msgstr ""
 
-#: ./ftw/news/browser/configure.zcml:64
+#: ./ftw/news/browser/configure.zcml:84
 msgid "Display the contents of a news folder."
 msgstr ""
 
@@ -62,7 +62,7 @@ msgstr ""
 msgid "News Folder"
 msgstr ""
 
-#: ./ftw/news/browser/configure.zcml:64
+#: ./ftw/news/browser/configure.zcml:84
 msgid "News listing"
 msgstr ""
 
@@ -78,7 +78,7 @@ msgstr ""
 msgid "NewsListingBlock"
 msgstr ""
 
-#: ./ftw/news/browser/templates/news_listing_block.pt:13
+#: ./ftw/news/browser/templates/news_listing_block.pt:14
 msgid "No content available"
 msgstr ""
 
@@ -94,12 +94,17 @@ msgstr ""
 msgid "RSS"
 msgstr ""
 
-#: ./ftw/news/browser/templates/news_listing_block.pt:54
+#: ./ftw/news/browser/templates/news_listing_block.pt:57
 msgid "Subscribe to the RSS feed"
 msgstr ""
 
 #: ./ftw/news/profiles/default/types/ftw.news.NewsListingBlock.xml
 msgid "The news listing block renders a configurable list of news entries."
+msgstr ""
+
+#. Default: "Hide the block if there are no news items to be shown."
+#: ./ftw/news/contents/news_listing_block.py:37
+msgid "description_hide_empty_block"
 msgstr ""
 
 #. Default: "The mopage data endpoint URL points to the \"mopage.news.xml\" view somewhere on the public visible  Plone page. It must also contain the params \"partnerid\" and \"importid\". Example: https://mypage.ch/news/mopage.news.xml?partnerid=3&importid=6"
@@ -113,7 +118,7 @@ msgid "description_mopage_trigger_url"
 msgstr ""
 
 #. Default: "This custom label will not be translated."
-#: ./ftw/news/contents/news_listing_block.py:22
+#: ./ftw/news/contents/news_listing_block.py:26
 msgid "description_more_news_link_label"
 msgstr ""
 
@@ -130,9 +135,19 @@ msgstr ""
 msgid "ftw.news (show on homepage feature)"
 msgstr ""
 
+#. Default: "The block is only visible to editors so it can still be edited."
+#: ./ftw/news/browser/templates/news_listing_block.pt:15
+msgid "hide_empty_block_text"
+msgstr ""
+
 #. Default: "${title} - News Feed"
-#: ./ftw/news/browser/news_listing.py:97
+#: ./ftw/news/browser/news_listing.py:102
 msgid "label_feed_desc"
+msgstr ""
+
+#. Default: "Hide empty block"
+#: ./ftw/news/contents/news_listing_block.py:35
+msgid "label_hide_empty_block"
 msgstr ""
 
 #. Default: "Mopage data endpoint URL (Plone)"
@@ -146,7 +161,7 @@ msgid "label_mopage_trigger_url"
 msgstr ""
 
 #. Default: "Label for the \"more news\" link"
-#: ./ftw/news/contents/news_listing_block.py:20
+#: ./ftw/news/contents/news_listing_block.py:24
 msgid "label_more_news_link_label"
 msgstr ""
 
@@ -169,9 +184,9 @@ msgid "mark news items to show up on home page"
 msgstr ""
 
 #. Default: "More News"
-#: ./ftw/news/browser/news_listing_block.py:36
-#: ./ftw/news/browser/templates/news_listing_block.pt:48
-#: ./ftw/news/portlets/templates/news_portlet.pt:37
+#: ./ftw/news/browser/news_listing_block.py:37
+#: ./ftw/news/browser/templates/news_listing_block.pt:51
+#: ./ftw/news/portlets/templates/news_portlet.pt:39
 msgid "more_news_link_label"
 msgstr ""
 
@@ -187,57 +202,57 @@ msgstr ""
 
 #. Default: "by ${author}"
 #: ./ftw/news/browser/templates/news_listing.pt:47
-#: ./ftw/news/browser/templates/news_listing_block.pt:30
+#: ./ftw/news/browser/templates/news_listing_block.pt:33
 msgid "news_listing_author_label"
 msgstr ""
 
 #. Default: "Show title"
-#: ./ftw/news/contents/news_listing_block.py:14
+#: ./ftw/news/contents/news_listing_block.py:18
 msgid "news_listing_block_show_title_label"
 msgstr ""
 
 #. Default: "You can not filter by path and current context at the same time."
-#: ./ftw/news/contents/common.py:127
+#: ./ftw/news/contents/common.py:125
 msgid "news_listing_config_current_context_and_path_error"
 msgstr ""
 
 #. Default: "The maximum length of the news item's description. Longer descriptions will be cropped. Enter 0 for no limitation."
-#: ./ftw/news/contents/common.py:78
+#: ./ftw/news/contents/common.py:76
 msgid "news_listing_config_description_length_description"
 msgstr ""
 
 #. Default: "Length of the description"
-#: ./ftw/news/contents/common.py:76
+#: ./ftw/news/contents/common.py:74
 msgid "news_listing_config_description_length_label"
 msgstr ""
 
 #. Default: "Only show news items from the current context."
-#: ./ftw/news/contents/common.py:42
+#: ./ftw/news/contents/common.py:41
 msgid "news_listing_config_filter_current_context_description"
 msgstr ""
 
 #. Default: "Limit to current context"
-#: ./ftw/news/contents/common.py:40
+#: ./ftw/news/contents/common.py:39
 msgid "news_listing_config_filter_current_context_label"
 msgstr ""
 
 #. Default: "Only show news items from a specific path."
-#: ./ftw/news/contents/common.py:27
+#: ./ftw/news/contents/common.py:29
 msgid "news_listing_config_filter_path_description"
 msgstr ""
 
 #. Default: "Limit to path"
-#: ./ftw/news/contents/common.py:25
+#: ./ftw/news/contents/common.py:27
 msgid "news_listing_config_filter_path_label"
 msgstr ""
 
 #. Default: "Only news younger than this value will be rendered. Enter 0 for no limitation."
-#: ./ftw/news/contents/common.py:88
+#: ./ftw/news/contents/common.py:86
 msgid "news_listing_config_maximum_age_description"
 msgstr ""
 
 #. Default: "Maximum age (days)"
-#: ./ftw/news/contents/common.py:86
+#: ./ftw/news/contents/common.py:84
 msgid "news_listing_config_maximum_age_label"
 msgstr ""
 
@@ -252,62 +267,62 @@ msgid "news_listing_config_news_on_homepage_label"
 msgstr ""
 
 #. Default: "The number of news entries to be shown at most. Enter 0 for no limitation."
-#: ./ftw/news/contents/common.py:50
+#: ./ftw/news/contents/common.py:49
 msgid "news_listing_config_quantity_description"
 msgstr ""
 
 #. Default: "Quantity"
-#: ./ftw/news/contents/common.py:49
+#: ./ftw/news/contents/common.py:48
 msgid "news_listing_config_quantity_label"
 msgstr ""
 
 #. Default: "Show the description of the news item"
-#: ./ftw/news/contents/common.py:70
+#: ./ftw/news/contents/common.py:68
 msgid "news_listing_config_show_description_label"
 msgstr ""
 
 #. Default: "Renders a lead image (taken from the item's first text block having an image.)"
-#: ./ftw/news/contents/common.py:116
+#: ./ftw/news/contents/common.py:114
 msgid "news_listing_config_show_lead_image_description"
 msgstr ""
 
 #. Default: "Show lead image"
-#: ./ftw/news/contents/common.py:114
+#: ./ftw/news/contents/common.py:112
 msgid "news_listing_config_show_lead_image_label"
 msgstr ""
 
 #. Default: "Render a link to a page which renders more news (only if there is at least one news item."
-#: ./ftw/news/contents/common.py:98
+#: ./ftw/news/contents/common.py:96
 msgid "news_listing_config_show_more_news_link_description"
 msgstr ""
 
 #. Default: "Link to more news"
-#: ./ftw/news/contents/common.py:96
+#: ./ftw/news/contents/common.py:94
 msgid "news_listing_config_show_more_news_link_label"
 msgstr ""
 
 #. Default: "Render a link to the RSS feed of the news."
-#: ./ftw/news/contents/common.py:108
+#: ./ftw/news/contents/common.py:106
 msgid "news_listing_config_show_rss_link_description"
 msgstr ""
 
 #. Default: "Link to RSS feed"
-#: ./ftw/news/contents/common.py:106
+#: ./ftw/news/contents/common.py:104
 msgid "news_listing_config_show_rss_link_label"
 msgstr ""
 
 #. Default: "Only news with the selected subjects will be shown."
-#: ./ftw/news/contents/common.py:61
+#: ./ftw/news/contents/common.py:59
 msgid "news_listing_config_subjects_description"
 msgstr ""
 
 #. Default: "Filter by subject"
-#: ./ftw/news/contents/common.py:59
+#: ./ftw/news/contents/common.py:57
 msgid "news_listing_config_subjects_label"
 msgstr ""
 
 #. Default: "Title"
-#: ./ftw/news/contents/common.py:17
+#: ./ftw/news/contents/common.py:19
 msgid "news_listing_config_title_label"
 msgstr ""
 
@@ -317,52 +332,52 @@ msgid "news_listing_no_content_text"
 msgstr ""
 
 #. Default: "This portlet displays news items"
-#: ./ftw/news/portlets/news_portlet.py:34
+#: ./ftw/news/portlets/news_portlet.py:35
 msgid "news_portlet_add_form_description"
 msgstr ""
 
 #. Default: "Add News Portlet"
-#: ./ftw/news/portlets/news_portlet.py:33
+#: ./ftw/news/portlets/news_portlet.py:34
 msgid "news_portlet_add_form_label"
 msgstr ""
 
 #. Default: "Render the portlet even if there are no news entries."
-#: ./ftw/news/portlets/news_portlet.py:25
+#: ./ftw/news/portlets/news_portlet.py:26
 msgid "news_portlet_always_render_portlet_description"
 msgstr ""
 
 #. Default: "Always render the portlet"
-#: ./ftw/news/portlets/news_portlet.py:23
+#: ./ftw/news/portlets/news_portlet.py:24
 msgid "news_portlet_always_render_portlet_label"
 msgstr ""
 
 #. Default: "Cancel"
-#: ./ftw/news/portlets/news_portlet.py:255
+#: ./ftw/news/portlets/news_portlet.py:258
 msgid "news_portlet_edit_form_cancel_label"
 msgstr ""
 
 #. Default: "This portlet displays news items"
-#: ./ftw/news/portlets/news_portlet.py:217
+#: ./ftw/news/portlets/news_portlet.py:220
 msgid "news_portlet_edit_form_description"
 msgstr ""
 
 #. Default: "Edit News Portlet"
-#: ./ftw/news/portlets/news_portlet.py:216
+#: ./ftw/news/portlets/news_portlet.py:219
 msgid "news_portlet_edit_form_label"
 msgstr ""
 
 #. Default: "Save"
-#: ./ftw/news/portlets/news_portlet.py:238
+#: ./ftw/news/portlets/news_portlet.py:241
 msgid "news_portlet_edit_form_save_label"
 msgstr ""
 
 #. Default: "No recent news available."
-#: ./ftw/news/portlets/templates/news_portlet.pt:13
+#: ./ftw/news/portlets/templates/news_portlet.pt:14
 msgid "no_recent_news_label"
 msgstr ""
 
 #. Default: "Subscribe to the RSS feed"
-#: ./ftw/news/portlets/templates/news_portlet.pt:43
+#: ./ftw/news/portlets/templates/news_portlet.pt:45
 msgid "rss_link_title"
 msgstr ""
 

--- a/ftw/news/tests/test_news_listing_block.py
+++ b/ftw/news/tests/test_news_listing_block.py
@@ -355,3 +355,31 @@ class TestNewsListingBlockContentType(FunctionalTestCase):
             [],
             browser.css('.sl-block.ftw-news-newslistingblock .news-item .title').text
         )
+
+    @browsing
+    def test_block_without_news_can_be_marked_as_hidden(self, browser):
+        """
+        This test makes sure that there is a CSS class "hidden" on the block
+        if the block is empty and the block has been configured accordingly.
+        """
+        page = create(Builder('sl content page'))
+        block = create(Builder('news listing block')
+                       .within(page)
+                       .titled(u'News listing block'))
+
+        def _block_has_hidden_class(browser):
+            return 'hidden' in browser.css('.ftw-news-newslistingblock').first.attrib['class']
+
+        browser.login()
+
+        # Make sure the block has no "hidden" class.
+        browser.visit(page)
+        self.assertFalse(_block_has_hidden_class(browser))
+
+        # Edit the block.
+        browser.visit(block, view='edit')
+        browser.fill({u'Hide empty block': True}).find('Save').click()
+
+        # Make sure the block has a "hidden" class now.
+        browser.visit(page)
+        self.assertTrue(_block_has_hidden_class(browser))


### PR DESCRIPTION
This is a backport of #98 