### PR TITLE
Fix hidden empty blocks.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.10.1 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Bugfix of the option to hide emtpy news listing block introduced
+  in 1.10.0. [mbaechtold]
 
 
 1.10.0 (2017-10-12)

--- a/ftw/news/contents/news_listing_block.py
+++ b/ftw/news/contents/news_listing_block.py
@@ -65,7 +65,7 @@ class NewsListingBlock(Container):
 
         items = api.content.get_view(
             name='block_view', context=obj, request=obj.REQUEST
-        ).get_items()
+        ).get_news()
         return self.hide_empty_block and not items
 
     @is_hidden.setter

--- a/ftw/news/tests/test_news_listing_block.py
+++ b/ftw/news/tests/test_news_listing_block.py
@@ -436,3 +436,30 @@ class TestNewsListingBlockContentType(FunctionalTestCase):
         # Make sure the block has a "hidden" class now.
         browser.visit(page)
         self.assertTrue(_block_has_hidden_class(browser))
+
+    @browsing
+    def test_hidden_empty_block_can_be_seen_by_admin(self, browser):
+        page = create(Builder('sl content page'))
+        create(Builder('news listing block')
+               .within(page)
+               .titled(u'News listing block')
+               .having(hide_empty_block=True))
+
+        # Authorized users can see the empty news listing block.
+        browser.login()
+        browser.visit(page)
+        self.assertEqual(
+            [
+                'No content available',
+                'The block is only visible to editors so it can still be edited.'
+            ],
+            browser.css('.ftw-news-newslistingblock p').text
+        )
+
+        # Anonymous users do not see the empty news listing block.
+        browser.logout()
+        browser.visit(page)
+        self.assertEqual(
+            [],
+            browser.css('.ftw-news-newslistingblock').text
+        )


### PR DESCRIPTION
Hiding empty news listing blocks did not work due to a programmer error.