### PR TITLE
Fix navigation link when user on /news_listing

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.10.2 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Swap the NewsListingBlock default view from "block_view" to "@@redirect_to_parent" [Nachtalb]
 
 
 1.10.1 (2017-12-19)

--- a/ftw/news/profiles/default/types/ftw.news.NewsListingBlock.xml
+++ b/ftw/news/profiles/default/types/ftw.news.NewsListingBlock.xml
@@ -22,10 +22,10 @@
         <element value="plone.app.referenceablebehavior.referenceable.IReferenceable"/>
     </property>
 
-    <property name="default_view">block_view</property>
+    <property name="default_view">@@redirect_to_parent</property>
     <property name="default_view_fallback">False</property>
     <property name="view_methods">
-        <element value="block_view"/>
+        <element value="@@redirect_to_parent"/>
     </property>
 
     <alias from="(Default)" to="(dynamic view)"/>

--- a/ftw/news/tests/test_news_listing_block.py
+++ b/ftw/news/tests/test_news_listing_block.py
@@ -383,7 +383,7 @@ class TestNewsListingBlockContentType(FunctionalTestCase):
 
         # By default, the block renders news from the children of
         # its container.
-        browser.visit(block)
+        browser.visit(block.absolute_url() + '/block_view')
         self.assertEqual(
             [
                 'A News Item in News Folder 1',
@@ -399,7 +399,7 @@ class TestNewsListingBlockContentType(FunctionalTestCase):
         ]
         transaction.commit()
 
-        browser.visit(block)
+        browser.reload()
         self.assertEqual(
             [
                 'A News Item in News Folder 1',

--- a/ftw/news/tests/test_news_listing_rss.py
+++ b/ftw/news/tests/test_news_listing_rss.py
@@ -109,7 +109,7 @@ class TestNewsRssListing(FunctionalTestCase):
             # were failing between the 1st and the 9th every month :-)
             # %-e Removes the leading space - only works on unix machines.
             DateTime(news.news_date).rfc822(),
-            browser.css('rss item pubDate').first.text
+            browser.css('rss item pubdate').first.text
         )
 
         # Same test but with the view from "ftw.contentpage" for backward compatibility.
@@ -124,7 +124,7 @@ class TestNewsRssListing(FunctionalTestCase):
             # were failing between the 1st and the 9th every month :-)
             # %-e Removes the leading space - only works on unix machines.
             DateTime(news.news_date).rfc822(),
-            browser.css('rss item pubDate').first.text
+            browser.css('rss item pubdate').first.text
         )
 
     @browsing

--- a/ftw/news/upgrades/20180822153109_fix_broken_navigation_link/types/ftw.news.NewsListingBlock.xml
+++ b/ftw/news/upgrades/20180822153109_fix_broken_navigation_link/types/ftw.news.NewsListingBlock.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<object name="ftw.news.NewsListingBlock">
+    <property name="default_view">@@redirect_to_parent</property>
+    <property name="view_methods">
+        <element value="@@redirect_to_parent"/>
+    </property>
+</object>

--- a/ftw/news/upgrades/20180822153109_fix_broken_navigation_link/upgrade.py
+++ b/ftw/news/upgrades/20180822153109_fix_broken_navigation_link/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class FixBrokenNavigationLink(UpgradeStep):
+    """Fix broken navigation link.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()


### PR DESCRIPTION
When a user visits the `/news_listing` view of a NewsListingBlock the navgation entry is redirects to the `/block_view`. We do not want this, it can make the user think that this is an error, because it is a plain html site without css and so on.