### PR TITLE
Add plone5 support

### DIFF
--- a/development.cfg
+++ b/development.cfg
@@ -1,4 +1,4 @@
 [buildout]
 extends =
-    test-plone-4.3.x.cfg
+    test-plone-5.1.x.cfg
     https://raw.github.com/4teamwork/ftw-buildouts/master/plone-development.cfg

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.10.3 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Move ressources to plone bundle. [busykoala]
 
 
 1.10.2 (2018-08-22)

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.10.3 (unreleased)
 -------------------
 
-- Move ressources to plone bundle. [busykoala]
+- Move ressources to plone bundle and adapt tests for plone 5.1 (especially
+  an adaption in xml parsing) [busykoala]
 
 
 1.10.2 (2018-08-22)

--- a/ftw/news/browser/mopage.py
+++ b/ftw/news/browser/mopage.py
@@ -90,6 +90,7 @@ class NewsMopageRenderer(SimplelayoutRenderer):
         We therefore convert the HTML to text and back to HTML.
         We also need to make sure that the result is less than 10000 long.
         """
+        self.request.RESPONSE.setHeader('X-Theme-Disabled', 'True')
         html = self.render_slot().strip()
 
         doc = lxml.html.fromstring(html)
@@ -132,6 +133,7 @@ class MopageNews(BrowserView):
     """
 
     def __call__(self):
+        self.request.RESPONSE.setHeader('X-Theme-Disabled', 'True')
         self.request.RESPONSE.setHeader('Cache-Control', 'no-store')
         self.request.RESPONSE.setHeader('Content-Type',
                                         'text/xml;charset=utf-8')

--- a/ftw/news/configure.zcml
+++ b/ftw/news/configure.zcml
@@ -22,11 +22,30 @@
     <i18n:registerTranslations directory="locales" />
 
     <genericsetup:registerProfile
+        zcml:condition="not-have plone-5"
         name="default"
         title="ftw.news"
         directory="profiles/default"
-        description=""
+        description="Register ftw.news generally"
         provides="Products.GenericSetup.interfaces.EXTENSION"
+        />
+
+    <genericsetup:registerProfile
+        zcml:condition="have plone-5"
+        name="default"
+        title="ftw.news"
+        directory="profiles/default_plone5"
+        description="Register ftw.news generally"
+        provides="Products.GenericSetup.interfaces.EXTENSION"
+        />
+
+    <genericsetup:registerProfile
+        zcml:condition="have plone-5"
+        name="uninstall"
+        title="Uninstall ftw.news"
+        directory="profiles/uninstall_plone5"
+        provides="Products.GenericSetup.interfaces.EXTENSION"
+        for="Products.CMFPlone.interfaces.IMigratingPloneSiteRoot"
         />
 
     <genericsetup:registerProfile

--- a/ftw/news/profiles/default_plone5/browserlayer.xml
+++ b/ftw/news/profiles/default_plone5/browserlayer.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<layers>
+
+    <layer name="ftw.news"
+           interface="ftw.news.interfaces.IFtwNewsLayer" />
+
+</layers>

--- a/ftw/news/profiles/default_plone5/metadata.xml
+++ b/ftw/news/profiles/default_plone5/metadata.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<metadata>
+    <dependencies>
+        <dependency>profile-ftw.simplelayout.contenttypes:default</dependency>
+        <dependency>profile-ftw.datepicker:default</dependency>
+        <dependency>profile-ftw.upgrade:default</dependency>
+        <dependency>profile-ftw.keywordwidget:default</dependency>
+        <dependency>profile-ftw.referencewidget:default</dependency>
+    </dependencies>
+</metadata>

--- a/ftw/news/profiles/default_plone5/portlets.xml
+++ b/ftw/news/profiles/default_plone5/portlets.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<portlets>
+
+    <portlet
+        addview="newsportlet"
+        title="News Portlet (ftw.news)"
+        description=""
+        />
+
+    <portlet
+        addview="newsarchiveportlet"
+        title="News Archive Portlet (ftw.news)"
+        description=""
+        />
+
+</portlets>

--- a/ftw/news/profiles/default_plone5/propertiestool.xml
+++ b/ftw/news/profiles/default_plone5/propertiestool.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<object name="portal_properties" meta_type="Plone Properties Tool">
+
+    <object name="navtree_properties" meta_type="Plone Property Sheet">
+        <property name="metaTypesNotToList" type="lines" purge="False">
+            <element value="ftw.news.NewsListingBlock"/>
+            <element value="ftw.news.News"/>
+        </property>
+    </object>
+
+    <object name="site_properties" meta_type="Plone Property Sheet">
+        <property name="types_not_searched" type="lines" purge="False">
+            <element value="ftw.news.NewsListingBlock"/>
+        </property>
+    </object>
+
+    <object name="imaging_properties" meta_type="Plone Property Sheet">
+        <property name="allowed_sizes" type="lines" purge="False">
+            <element value="news_listing_image 480:480"/>
+        </property>
+    </object>
+
+</object>

--- a/ftw/news/profiles/default_plone5/registry.xml
+++ b/ftw/news/profiles/default_plone5/registry.xml
@@ -1,5 +1,13 @@
 <registry>
 
+    <records
+        interface="Products.CMFPlone.interfaces.controlpanel.IImagingSchema"
+        prefix="plone">
+        <value key="allowed_sizes" purge="false">
+            <element>news_listing_image 480:480</element>
+        </value>
+    </records>
+
     <records prefix="plone.resources/ftw-news-js"
              interface='Products.CMFPlone.interfaces.IResourceRegistry'>
         <value key="js">++resource++ftw.news.resources/archive.js</value>

--- a/ftw/news/profiles/default_plone5/registry.xml
+++ b/ftw/news/profiles/default_plone5/registry.xml
@@ -1,0 +1,30 @@
+<registry>
+
+    <records prefix="plone.resources/ftw-news-js"
+             interface='Products.CMFPlone.interfaces.IResourceRegistry'>
+        <value key="js">++resource++ftw.news.resources/archive.js</value>
+        <value key="deps">jquery</value>
+    </records>
+
+    <records prefix="plone.resources/ftw-news-styles"
+             interface='Products.CMFPlone.interfaces.IResourceRegistry'>
+        <value key="css">
+            <element>++resource++ftw.news.resources/news.css</element>
+        </value>
+    </records>
+
+    <records prefix="plone.bundles/ftw-news-resources"
+             interface='Products.CMFPlone.interfaces.IBundleRegistry'>
+        <value key="resources">
+            <element>ftw-news-styles</element>
+            <element>ftw-news-js</element>
+        </value>
+        <value key="enabled">True</value>
+        <value key="depends">plone-legacy</value>
+        <value key="compile">False</value>
+        <value key="jscompilation">++plone++datetimepicker/ftw-news-compiled.js</value>
+        <value key="csscompilation">++plone++datetimepicker/ftw-news-compiled.css</value>
+        <value key="merge_with">default</value>
+    </records>
+
+</registry>

--- a/ftw/news/profiles/default_plone5/rolemap.xml
+++ b/ftw/news/profiles/default_plone5/rolemap.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0"?>
+<rolemap>
+    <permissions>
+
+        <permission name="ftw.news: Add NewsFolder" acquire="False">
+            <role name="Manager"/>
+            <role name="Site Administrator"/>
+            <role name="Contributor"/>
+        </permission>
+
+        <permission name="ftw.news: Add News" acquire="False">
+            <role name="Manager"/>
+            <role name="Site Administrator"/>
+            <role name="Contributor"/>
+        </permission>
+
+        <permission name="ftw.news: Add NewsListingBlock" acquire="False">
+            <role name="Manager"/>
+            <role name="Site Administrator"/>
+            <role name="Contributor"/>
+        </permission>
+
+        <permission name="ftw.news: Configure mopage trigger" acquire="False">
+            <role name="Manager"/>
+            <role name="Site Administrator"/>
+        </permission>
+
+        <permission name="ftw.news: Edit news external url" acquire="False">
+            <role name="Manager"/>
+            <role name="Site Administrator"/>
+        </permission>
+
+    </permissions>
+</rolemap>

--- a/ftw/news/profiles/default_plone5/tinymce.xml
+++ b/ftw/news/profiles/default_plone5/tinymce.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<object>
+    <resourcetypes>
+        <linkable purge="False">
+            <element value="ftw.news.NewsFolder"/>
+            <element value="ftw.news.News"/>
+        </linkable>
+    </resourcetypes>
+</object>

--- a/ftw/news/profiles/default_plone5/types.xml
+++ b/ftw/news/profiles/default_plone5/types.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<object name="portal_types" meta_type="Plone Types Tool">
+    <object name="ftw.news.NewsFolder" meta_type="Dexterity FTI"/>
+    <object name="ftw.news.News" meta_type="Dexterity FTI"/>
+    <object name="ftw.news.NewsListingBlock" meta_type="Dexterity FTI"/>
+</object>

--- a/ftw/news/profiles/default_plone5/types/Plone_Site.xml
+++ b/ftw/news/profiles/default_plone5/types/Plone_Site.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<object name="Plone Site">
+
+    <property name="allowed_content_types" purge="False">
+        <element value="ftw.news.NewsFolder" />
+        <element value="ftw.news.NewsListingBlock" />
+    </property>
+
+</object>

--- a/ftw/news/profiles/default_plone5/types/ftw.news.News.xml
+++ b/ftw/news/profiles/default_plone5/types/ftw.news.News.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0"?>
+<object name="ftw.news.News"
+        meta_type="Dexterity FTI"
+        xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+        i18n:domain="ftw.news" >
+
+    <property name="title" i18n:translate="">News</property>
+    <property name="description" i18n:translate=""></property>
+    <property name="icon_expr"></property>
+    <property name="allow_discussion">False</property>
+    <property name="global_allow">False</property>
+    <property name="filter_content_types">True</property>
+    <property name="allowed_content_types">
+        <element value="ftw.simplelayout.TextBlock" />
+        <element value="ftw.simplelayout.FileListingBlock" />
+        <element value="ftw.simplelayout.MapBlock" />
+        <element value="ftw.simplelayout.VideoBlock" />
+        <element value="ftw.simplelayout.GalleryBlock" />
+    </property>
+
+    <property name="schema">ftw.news.contents.news.INewsSchema</property>
+    <property name="klass">ftw.news.contents.news.News</property>
+    <property name="add_permission">ftw.news.AddNews</property>
+
+    <property name="behaviors">
+        <element value="ftw.simplelayout.interfaces.ISimplelayout" />
+        <element value="plone.app.dexterity.behaviors.metadata.IBasic"/>
+        <element value="collective.dexteritytextindexer.behavior.IDexterityTextIndexer" />
+        <element value="plone.app.content.interfaces.INameFromTitle" />
+        <element value="plone.app.dexterity.behaviors.metadata.ICategorization" remove="True" />
+        <element value="ftw.keywordwidget.behavior.IKeywordCategorization" />
+        <element value="plone.app.referenceablebehavior.referenceable.IReferenceable"/>
+        <element value="plone.app.dexterity.behaviors.metadata.IPublication" />
+    </property>
+
+    <property name="default_view">@@simplelayout-view</property>
+    <property name="default_view_fallback">False</property>
+    <property name="view_methods">
+        <element value="@@simplelayout-view"/>
+    </property>
+
+    <alias from="(Default)" to="(dynamic view)"/>
+    <alias from="edit" to="@@edit"/>
+    <alias from="sharing" to="@@sharing"/>
+    <alias from="view" to="(selected layout)"/>
+
+    <action
+        action_id="view"
+        title="View"
+        category="object"
+        condition_expr=""
+        url_expr="string:${object_url}"
+        visible="True">
+        <permission value="View"/>
+    </action>
+
+    <action
+        action_id="edit"
+        title="Edit"
+        category="object"
+        condition_expr=""
+        url_expr="string:${object_url}/edit"
+        visible="True">
+        <permission value="Modify portal content"/>
+    </action>
+
+</object>

--- a/ftw/news/profiles/default_plone5/types/ftw.news.NewsFolder.xml
+++ b/ftw/news/profiles/default_plone5/types/ftw.news.NewsFolder.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0"?>
+<object name="ftw.news.NewsFolder"
+        meta_type="Dexterity FTI"
+        xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+        i18n:domain="ftw.news" >
+
+    <property name="title" i18n:translate="">News Folder</property>
+    <property name="description" i18n:translate="">A container for news items.</property>
+    <property name="icon_expr"></property>
+    <property name="allow_discussion">False</property>
+    <property name="global_allow">True</property>
+    <property name="filter_content_types">True</property>
+    <property name="allowed_content_types">
+        <element value="ftw.news.News"></element>
+        <element value="ftw.news.NewsListingBlock" />
+        <element value="ftw.simplelayout.FileListingBlock" />
+        <element value="ftw.simplelayout.GalleryBlock" />
+        <element value="ftw.simplelayout.MapBlock" />
+        <element value="ftw.simplelayout.TextBlock" />
+        <element value="ftw.simplelayout.VideoBlock" />
+    </property>
+
+    <property name="schema">ftw.news.contents.news_folder.INewsFolderSchema</property>
+    <property name="klass">ftw.news.contents.news_folder.NewsFolder</property>
+    <property name="add_permission">ftw.news.AddNewsFolder</property>
+
+    <property name="behaviors">
+        <element value="plone.app.dexterity.behaviors.metadata.IBasic"/>
+        <element value="plone.app.content.interfaces.INameFromTitle" />
+        <element value="plone.app.referenceablebehavior.referenceable.IReferenceable"/>
+        <element value="plone.app.dexterity.behaviors.exclfromnav.IExcludeFromNavigation" />
+        <element value="ftw.simplelayout.interfaces.ISimplelayout" />
+    </property>
+
+    <property name="immediate_view">simplelayout-view</property>
+    <property name="default_view">simplelayout-view</property>
+    <property name="view_methods">
+        <element value="simplelayout-view"/>
+        <element value="news_listing"/>
+    </property>
+    <property name="default_view_fallback">False</property>
+
+    <alias from="(Default)" to="(dynamic view)" />
+    <alias from="view" to="(selected layout)" />
+    <alias from="edit" to="@@edit" />
+    <alias from="sharing" to="@@sharing" />
+
+    <action
+        action_id="view"
+        title="View"
+        category="object"
+        condition_expr=""
+        url_expr="string:${object_url}"
+        visible="True">
+        <permission value="View"/>
+    </action>
+
+    <action
+        action_id="edit"
+        title="Edit"
+        category="object"
+        condition_expr=""
+        url_expr="string:${object_url}/edit"
+        visible="True">
+        <permission value="Modify portal content"/>
+    </action>
+
+</object>

--- a/ftw/news/profiles/default_plone5/types/ftw.news.NewsListingBlock.xml
+++ b/ftw/news/profiles/default_plone5/types/ftw.news.NewsListingBlock.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0"?>
+<object name="ftw.news.NewsListingBlock"
+        meta_type="Dexterity FTI"
+        xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+        i18n:domain="ftw.news" >
+
+    <property name="title" i18n:translate="">NewsListingBlock</property>
+    <property name="description" i18n:translate="">The news listing block renders a configurable list of news entries.</property>
+    <property name="icon_expr"></property>
+    <property name="allow_discussion">False</property>
+    <property name="global_allow">False</property>
+    <property name="filter_content_types">True</property>
+    <property name="allowed_content_types"></property>
+
+    <property name="schema">ftw.news.contents.news_listing_block.INewsListingBlockSchema</property>
+    <property name="klass">ftw.news.contents.news_listing_block.NewsListingBlock</property>
+    <property name="add_permission">ftw.news.AddNewsListingBlock</property>
+
+    <property name="behaviors">
+        <element value="plone.app.content.interfaces.INameFromTitle" />
+        <element value="ftw.simplelayout.interfaces.ISimplelayoutBlock" />
+        <element value="plone.app.referenceablebehavior.referenceable.IReferenceable"/>
+    </property>
+
+    <property name="default_view">@@redirect_to_parent</property>
+    <property name="default_view_fallback">False</property>
+    <property name="view_methods">
+        <element value="@@redirect_to_parent"/>
+    </property>
+
+    <alias from="(Default)" to="(dynamic view)"/>
+    <alias from="edit" to="@@edit"/>
+    <alias from="sharing" to="@@sharing"/>
+    <alias from="view" to="(selected layout)"/>
+
+</object>

--- a/ftw/news/profiles/default_plone5/types/ftw.simplelayout.ContentPage.xml
+++ b/ftw/news/profiles/default_plone5/types/ftw.simplelayout.ContentPage.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<object name="ContentPage">
+    
+    <property name="allowed_content_types" purge="False">
+        <element value="ftw.news.NewsListingBlock"/>
+        <element value="ftw.news.NewsFolder"/>
+    </property>
+    
+</object>

--- a/ftw/news/profiles/default_plone5/workflows.xml
+++ b/ftw/news/profiles/default_plone5/workflows.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<object name="portal_workflow" meta_type="Plone Workflow Tool">
+    <bindings>
+        <type type_id="ftw.news.NewsListingBlock"/>
+    </bindings>
+</object>

--- a/ftw/news/profiles/uninstall_plone5/registry.xml
+++ b/ftw/news/profiles/uninstall_plone5/registry.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<registry>
+    <records prefix="plone.resources/ftw-news-styles"
+             interface='Products.CMFPlone.interfaces.IResourceRegistry'
+             remove="True"/>
+    <records prefix="plone.resources/ftw-news-js"
+             interface='Products.CMFPlone.interfaces.IResourceRegistry'
+             remove="True"/>
+    <records prefix="plone.bundles/ftw-news-resources"
+             interface='Products.CMFPlone.interfaces.IBundleRegistry'
+             remove="True"/>
+</registry>

--- a/ftw/news/testing.py
+++ b/ftw/news/testing.py
@@ -3,14 +3,15 @@ from collective.taskqueue.testing import ZSERVER_FIXTURE
 from ftw.builder.testing import BUILDER_LAYER
 from ftw.builder.testing import functional_session_factory
 from ftw.builder.testing import set_builder_session_factory
-from ftw.testing.layer import COMPONENT_REGISTRY_ISOLATION
-from plone.app.testing import applyProfile
-from plone.app.testing import FunctionalTesting
-from plone.app.testing import PloneSandboxLayer
-from plone.testing import z2
-from zope.configuration import xmlconfig
 from ftw.simplelayout.tests import builders
 from ftw.subsite.tests import builders
+from ftw.testing import IS_PLONE_5
+from ftw.testing.layer import COMPONENT_REGISTRY_ISOLATION
+from plone.app.testing import FunctionalTesting
+from plone.app.testing import PloneSandboxLayer
+from plone.app.testing import applyProfile
+from plone.testing import z2
+from zope.configuration import xmlconfig
 import ftw.news.tests.builders
 
 
@@ -33,6 +34,8 @@ class FtwNewsLayer(PloneSandboxLayer):
         # Install into Plone site using portal_setup
         applyProfile(portal, 'ftw.news:default')
         applyProfile(portal, 'ftw.subsite:default')
+        if IS_PLONE_5:
+            applyProfile(portal, 'plone.app.contenttypes:default')
 
 
 FTW_NEWS_FIXTURE = FtwNewsLayer()

--- a/ftw/news/tests/base.py
+++ b/ftw/news/tests/base.py
@@ -1,9 +1,11 @@
+from StringIO import StringIO
+
+import transaction
 from ftw.news.testing import FTW_NEWS_FUNCTIONAL_TESTING
 from lxml import etree
-from plone.app.testing import setRoles, TEST_USER_ID
-from StringIO import StringIO
+from plone.app.testing import TEST_USER_ID
+from plone.app.testing import setRoles
 from unittest2 import TestCase
-import transaction
 
 
 class FunctionalTestCase(TestCase):
@@ -19,8 +21,11 @@ class FunctionalTestCase(TestCase):
 
 class XMLDiffTestCase(TestCase):
 
-    def _canonicalize_xml(self, text, node_sorter=None):
-        parser = etree.XMLParser(remove_blank_text=True)
+    def _canonicalize_xml(self, text, node_sorter=None, encoding=None):
+        if not encoding:
+            encoding = 'utf-8'
+
+        parser = etree.XMLParser(remove_blank_text=True, encoding=encoding)
         try:
             xml = etree.fromstring(text, parser)
         except etree.XMLSyntaxError, exc:
@@ -45,7 +50,7 @@ class XMLDiffTestCase(TestCase):
                               encoding='utf-8')
 
     def assert_xml(self, xml1, xml2):
-        norm1 = self._canonicalize_xml(xml1)
-        norm2 = self._canonicalize_xml(xml2)
+        norm1 = self._canonicalize_xml(xml1, encoding='iso-8859-15')
+        norm2 = self._canonicalize_xml(xml2, encoding='utf-8')
         self.maxDiff = None
         self.assertMultiLineEqual(norm1, norm2)

--- a/ftw/news/tests/mopage_assets/01_export_news_plone5.xml
+++ b/ftw/news/tests/mopage_assets/01_export_news_plone5.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="iso-8859-15" ?>
+<import export_time="2011-01-02 03:04:00">
+
+    <item status="1" suchbar="1" mutationsdatum="2010-05-17 15:34:00" datumvon="2010-05-18 12:00:00" datumbis="2020-01-01 00:00:00">
+        <id>uid00000000000000000000000000005</id>
+        <titel>Largest Aircraft in the World</titel>
+        <textlead></textlead>
+
+        <textmobile>
+            <![CDATA[]]>
+        </textmobile>
+    </item>
+    <item status="1" suchbar="1" mutationsdatum="2010-03-15 00:00:00" datumvon="2010-03-15 12:00:00">
+        <id>uid00000000000000000000000000003</id>
+        <titel>Usain Bolt at the Ölympics</titel>
+        <textlead><![CDATA[Usain Bolt wins the Ölympic gold in three events.  The third is for a 100-metre relay.]]></textlead>
+        <url_bild>http://nohost/plone/news-folder/usain-bolt-at-the-olympics/ftw-simplelayout-textblock/image.jpg</url_bild>
+        <textmobile>
+            <![CDATA[Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sapientem locupletat ipsa natura, cuius divitias Epicurus parabiles esse docuit. Multa sunt dicta ab antiquis de contemnendis ac despiciendis rebus humanis.<br /><br />&nbsp;Lorem ipsum dolor sit amet, consectetur &quot;adipiscing&quot; elit. At certe gravius. Ut optime, secundum naturam &laquo;affectum&raquo; esse possit. Quia d&ouml;lori non voluptas contraria est, sed doloris privatio. Non minor, inquit, voluptas percipitur ex vilissimis rebus quam ex pretiosissimis. Sed nunc, quod agimus; Duo Reges: constructio interrete.]]>
+        </textmobile>
+        <rubrik>Homepage</rubrik>
+        <rubrik>Sports</rubrik>
+    </item>
+
+</import>

--- a/ftw/news/tests/test_content_types.py
+++ b/ftw/news/tests/test_content_types.py
@@ -5,6 +5,7 @@ from ftw.news.testing import FTW_NEWS_FUNCTIONAL_TESTING
 from ftw.news.tests.base import FunctionalTestCase
 from ftw.testbrowser import browsing
 from ftw.testbrowser.pages import factoriesmenu
+from ftw.testbrowser.pages import statusmessages
 from ftw.testing import freeze
 
 
@@ -23,9 +24,8 @@ class TestContentTypes(FunctionalTestCase):
 
         news_folder_title = u'This is a news folder'
         browser.fill({'Title': news_folder_title}).save()
-        browser.find(news_folder_title).click()
-        self.assertEqual(news_folder_title,
-                         browser.css('h1.documentFirstHeading').first.text)
+
+        statusmessages.assert_message(u'Item created')
 
     @browsing
     def test_news_folder_has_empty_listing_block(self, browser):

--- a/ftw/news/tests/test_mopage.py
+++ b/ftw/news/tests/test_mopage.py
@@ -1,4 +1,7 @@
+import re
 from datetime import datetime
+
+import transaction
 from DateTime import DateTime
 from ftw.builder import Builder
 from ftw.builder import create
@@ -8,13 +11,12 @@ from ftw.news.tests.base import FunctionalTestCase
 from ftw.news.tests.base import XMLDiffTestCase
 from ftw.testbrowser import browser
 from ftw.testbrowser import browsing
+from ftw.testing import IS_PLONE_5
 from ftw.testing import freeze
 from ftw.testing import staticuid
 from path import Path
 from plone.app.textfield import RichTextValue
 from Products.CMFCore.utils import getToolByName
-import re
-import transaction
 
 
 class TestMopageExport(FunctionalTestCase, XMLDiffTestCase):
@@ -58,7 +60,10 @@ class TestMopageExport(FunctionalTestCase, XMLDiffTestCase):
         create(Builder('file').with_dummy_content().within(listingblock))
 
         with freeze(datetime(2011, 1, 2, 3, 4)):
-            self.assert_mopage_export('01_export_news.xml', news_folder)
+            if IS_PLONE_5:
+                self.assert_mopage_export('01_export_news_plone5.xml', news_folder)
+            else:
+                self.assert_mopage_export('01_export_news.xml', news_folder)
 
     @browsing
     def test_pagination(self, browser):

--- a/ftw/news/tests/test_news_archive_portlets.py
+++ b/ftw/news/tests/test_news_archive_portlets.py
@@ -28,7 +28,8 @@ class TestNewsArchivePortlets(FunctionalTestCase):
         """
         context = context or self.portal
         browser.login().visit(context, view='@@manage-portlets')
-        browser.forms['form-3'].fill({':action': news_portlet_action}).submit()
+        browser.css('#portletmanager-plone-rightcolumn form')[0].fill(
+            {':action': news_portlet_action}).submit()
         browser.open(context)
 
     @browsing

--- a/ftw/news/tests/utils.py
+++ b/ftw/news/tests/utils.py
@@ -1,5 +1,7 @@
 from ftw.simplelayout.interfaces import IPageConfiguration
 from plone import api
+
+from ftw.testing import IS_PLONE_5
 from plone.uuid.interfaces import IUUID
 import transaction
 
@@ -26,6 +28,10 @@ def create_page_state(obj, block):
 
 
 def set_allow_anonymous_view_about(state):
-    site_props = api.portal.get_tool(name='portal_properties').site_properties
-    site_props.allowAnonymousViewAbout = state
+
+    if IS_PLONE_5:
+        api.portal.set_registry_record('plone.allow_anon_views_about', state)
+    else:
+        site_props = api.portal.get_tool(name='portal_properties').site_properties
+        site_props.allowAnonymousViewAbout = state
     transaction.commit()

--- a/ftw/news/utils.py
+++ b/ftw/news/utils.py
@@ -1,3 +1,4 @@
+from ftw.testing import IS_PLONE_5
 from plone import api
 
 
@@ -24,9 +25,14 @@ def can_view_about():
 
     :rtype: bool
     """
-    site_props = api.portal.get_tool(name='portal_properties').site_properties
-    allow_anonymous_view_about = site_props.getProperty(
-        'allowAnonymousViewAbout', False)
+    if IS_PLONE_5:
+        allow_anonymous_view_about = api.portal.get_registry_record(
+            'plone.allow_anon_views_about')
+    else:
+        site_props = api.portal.get_tool(
+            name='portal_properties').site_properties
+        allow_anonymous_view_about = site_props.getProperty(
+            'allowAnonymousViewAbout', False)
 
     if not allow_anonymous_view_about and api.user.is_anonymous():
         return False

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ tests_require = [
     'path.py',
     'plone.app.testing',
     'plone.testing',
+    'plone.app.contenttypes',
 ]
 
 extras_require = {

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,7 @@ setup(
     classifiers=[
         'Framework :: Plone',
         'Framework :: Plone :: 4.3',
+        'Framework :: Plone :: 5.1'
         'License :: OSI Approved :: GNU General Public License (GPL)',
         'Programming Language :: Python',
         'Programming Language :: Python :: 2.7',

--- a/sources.cfg
+++ b/sources.cfg
@@ -6,6 +6,8 @@ extensions += mr.developer
 
 auto-checkout =
     ftw.subsite
+    ftw.keywordwidget
 
 [branches]
 ftw.subsite = plone-5.1.x
+ftw.keywordwidget = plone-5.1.x

--- a/sources.cfg
+++ b/sources.cfg
@@ -5,3 +5,7 @@ extends =
 extensions += mr.developer
 
 auto-checkout =
+    ftw.subsite
+
+[branches]
+ftw.subsite = plone-5.1.x

--- a/sources.cfg
+++ b/sources.cfg
@@ -9,11 +9,9 @@ auto-checkout =
     ftw.keywordwidget
     ftw.events
     ftw.publisher.core
-    ftw.simplelayout
 
 [branches]
 ftw.subsite = plone-5.1.x
 ftw.keywordwidget = plone-5.1.x
 ftw.events = mo/plone5
 ftw.publisher.core = master
-ftw.simplelayout = master

--- a/sources.cfg
+++ b/sources.cfg
@@ -7,7 +7,11 @@ extensions += mr.developer
 auto-checkout =
     ftw.subsite
     ftw.keywordwidget
+    ftw.events
+    ftw.publisher.core
 
 [branches]
 ftw.subsite = plone-5.1.x
 ftw.keywordwidget = plone-5.1.x
+ftw.events = mo/plone5
+ftw.publisher.core = master

--- a/sources.cfg
+++ b/sources.cfg
@@ -9,9 +9,11 @@ auto-checkout =
     ftw.keywordwidget
     ftw.events
     ftw.publisher.core
+    ftw.simplelayout
 
 [branches]
 ftw.subsite = plone-5.1.x
 ftw.keywordwidget = plone-5.1.x
 ftw.events = mo/plone5
 ftw.publisher.core = master
+ftw.simplelayout = master

--- a/test-plone-5.1.x.cfg
+++ b/test-plone-5.1.x.cfg
@@ -1,0 +1,6 @@
+[buildout]
+extends =
+    https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-plone-5.1.5.cfg
+    sources.cfg
+
+package-name = ftw.news


### PR DESCRIPTION
In this pull request resources are bundled ready for Plone 5.1

Apart from that we had to fix some tests:
- A menu does not exist anymore, so the button can't be clicked.
- The number of forms differs in Plone 5.1 therefore I select them by class instead.
- xml gets parsed a little different than before (newline is replaced by a whitespace)