### PR TITLE
Fix: Remove assertion for list order.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.11.2 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Bugfix: Adapt flaky test to not check list order [busykoala]
 
 
 1.11.1 (2019-03-22)

--- a/ftw/news/tests/test_news_listing_block.py
+++ b/ftw/news/tests/test_news_listing_block.py
@@ -384,7 +384,7 @@ class TestNewsListingBlockContentType(FunctionalTestCase):
         # By default, the block renders news from the children of
         # its container.
         browser.visit(block.absolute_url() + '/block_view')
-        self.assertEqual(
+        self.assertItemsEqual(
             [
                 'A News Item in News Folder 1',
                 'A News Item in News Folder 2',


### PR DESCRIPTION
Close #109 

This test is about checking if filtering is working. There is no need to
check the list order which lead to flakiness.
Now that I only check for the items in the list but not for the order
this behaviour should vanish.