### PR TITLE
Add ftw.testing as a dependency

### DIFF
--- a/ftw/news/utils.py
+++ b/ftw/news/utils.py
@@ -1,5 +1,7 @@
-from ftw.testing import IS_PLONE_5
 from plone import api
+import pkg_resources
+
+IS_PLONE_5 = pkg_resources.get_distribution('Products.CMFPlone').version >= '5'
 
 
 def get_creator(item):

--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,6 @@ setup(
         'plone.directives.form',
         'ftw.upgrade',
         'setuptools',
-        'ftw.testing',
     ],
 
     tests_require=tests_require,

--- a/setup.py
+++ b/setup.py
@@ -76,6 +76,7 @@ setup(
         'plone.directives.form',
         'ftw.upgrade',
         'setuptools',
+        'ftw.testing',
     ],
 
     tests_require=tests_require,


### PR DESCRIPTION
Because in plone 5.1 we want to use IS_PLONE_5 I need to add ftw.testing
as a dependency in ftw.news.