### PR TITLE
Fix news folder not shown in navigation (plone5)

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.11.3 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Fix news folder not shown in navigation (plone5) [Nachtalb]
 
 
 1.11.2 (2019-03-29)

--- a/ftw/news/profiles/default_plone5/registry.xml
+++ b/ftw/news/profiles/default_plone5/registry.xml
@@ -1,5 +1,11 @@
 <registry>
 
+    <record name="plone.displayed_types">
+        <value purge="false">
+            <element>ftw.news.NewsFolder</element>
+        </value>
+    </record>
+
     <records
         interface="Products.CMFPlone.interfaces.controlpanel.IImagingSchema"
         prefix="plone">

--- a/ftw/news/upgrades/20190501213953_fix_news_folder_not_shown_in_navigation__plone_5_/registry.xml
+++ b/ftw/news/upgrades/20190501213953_fix_news_folder_not_shown_in_navigation__plone_5_/registry.xml
@@ -1,0 +1,9 @@
+<registry>
+
+  <record name="plone.displayed_types">
+    <value purge="false">
+      <element>ftw.news.NewsFolder</element>
+    </value>
+  </record>
+
+</registry>

--- a/ftw/news/upgrades/20190501213953_fix_news_folder_not_shown_in_navigation__plone_5_/upgrade.py
+++ b/ftw/news/upgrades/20190501213953_fix_news_folder_not_shown_in_navigation__plone_5_/upgrade.py
@@ -1,0 +1,11 @@
+from ftw.news.utils import IS_PLONE_5
+from ftw.upgrade import UpgradeStep
+
+
+class FixNewsFolderNotShownInNavigationPlone5(UpgradeStep):
+    """Fix news folder not shown in navigation (Plone 5).
+    """
+
+    def __call__(self):
+        if IS_PLONE_5:
+            self.install_upgrade_profile()


### PR DESCRIPTION
In the upgrade to Plone 5 this little registry entry was forgotten. 