### PR TITLE
Remove obsolete source checkouts

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.11.3 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Remove obsolete source checkouts [Nachtalb]
 
 
 1.11.2 (2019-03-29)

--- a/sources.cfg
+++ b/sources.cfg
@@ -3,15 +3,3 @@ extends =
     http://kgs.4teamwork.ch/sources.cfg
 
 extensions += mr.developer
-
-auto-checkout =
-    ftw.subsite
-    ftw.keywordwidget
-    ftw.events
-    ftw.publisher.core
-
-[branches]
-ftw.subsite = plone-5.1.x
-ftw.keywordwidget = plone-5.1.x
-ftw.events = mo/plone5
-ftw.publisher.core = master


### PR DESCRIPTION
The defined branches do not exist anymore and lead to errors while buildouting. 