### PR TITLE
Be able to add custom "more items" link for NewsListingBlocks

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.12.1 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Be able to add custom "more items" link for NewsListingBlocks. [tinagerber]
 
 
 1.12.0 (2019-08-29)

--- a/ftw/news/browser/news_listing_block.py
+++ b/ftw/news/browser/news_listing_block.py
@@ -29,8 +29,10 @@ class NewsListingBlockView(BaseBlock):
 
         more_news_link_url = ''
         if self.context.show_more_news_link:
-            more_news_link_url = '/'.join([self.context.absolute_url(),
-                                           'news_listing'])
+            if self.context.link_to_more_items and self.context.link_to_more_items.to_object:
+                more_news_link_url = self.context.link_to_more_items.to_object.absolute_url()
+            else:
+                more_news_link_url = '/'.join([self.context.absolute_url(), 'news_listing'])
 
         more_news_link_label = (
             self.context.more_news_link_label or

--- a/ftw/news/contents/news_listing_block.py
+++ b/ftw/news/contents/news_listing_block.py
@@ -2,16 +2,26 @@ from Acquisition import aq_inner, aq_parent
 from ftw.news import _
 from ftw.news.contents.common import INewsListingBaseSchema
 from ftw.news.interfaces import INewsListingBlock
+from ftw.referencewidget.sources import DefaultSelectable
+from ftw.referencewidget.sources import ReferenceObjSourceBinder
+from ftw.referencewidget.widget import ReferenceWidgetFactory
 from ftw.simplelayout.contenttypes.behaviors import IHiddenBlock
 from plone import api
 from plone.autoform.interfaces import IFormFieldProvider
 from plone.dexterity.content import Container
 from plone.directives import form
 from plone.uuid.interfaces import IUUID
+from z3c.relationfield import RelationChoice
 from zope import schema
 from zope.interface import alsoProvides
 from zope.interface import implements
 
+
+class FilterByPathSelectable(DefaultSelectable):
+
+    def is_selectable(self):
+        """ Allow to reference any path"""
+        return True
 
 class INewsListingBlockSchema(INewsListingBaseSchema):
     show_title = schema.Bool(
@@ -28,8 +38,18 @@ class INewsListingBlockSchema(INewsListingBaseSchema):
         required=False,
     )
 
+    form.widget(link_to_more_items=ReferenceWidgetFactory)
+    link_to_more_items = RelationChoice(
+        title=_(u'news_listing_config_items_link', default=u'Link to more items'),
+        source=ReferenceObjSourceBinder(
+            selectable_class=FilterByPathSelectable),
+        default=None,
+        required=False,
+    )
+
     form.order_after(show_title='news_listing_config_title')
-    form.order_after(more_news_link_label='show_more_news_link')
+    form.order_after(link_to_more_items='show_more_news_link')
+    form.order_after(more_news_link_label='link_to_more_items')
 
     hide_empty_block = schema.Bool(
         title=_(u'label_hide_empty_block',

--- a/ftw/news/locales/de/LC_MESSAGES/ftw.news.po
+++ b/ftw/news/locales/de/LC_MESSAGES/ftw.news.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2019-08-29 12:03+0000\n"
+"POT-Creation-Date: 2019-09-10 12:38+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -117,7 +117,7 @@ msgid "archive"
 msgstr ""
 
 #. Default: "Hide the block if there are no news items to be shown."
-#: ./ftw/news/contents/news_listing_block.py:37
+#: ./ftw/news/contents/news_listing_block.py:56
 msgid "description_hide_empty_block"
 msgstr "Der Block wird nicht angezeigt, wenn keine News-Einträge vorhanden sind."
 
@@ -132,7 +132,7 @@ msgid "description_mopage_trigger_url"
 msgstr "Die Trigger-URL zeigt auf die Mopage-API. Sie enthält kein \"?url\"-Parameter, dieser wird automatisch angefügt. Beispiel: https://un:pw@xml.mopage.ch/infoservice/xml.php"
 
 #. Default: "This custom label will not be translated."
-#: ./ftw/news/contents/news_listing_block.py:26
+#: ./ftw/news/contents/news_listing_block.py:36
 msgid "description_more_news_link_label"
 msgstr "Dieses Label wird nicht übersetzt."
 
@@ -160,7 +160,7 @@ msgid "label_feed_desc"
 msgstr "${title} - News Feed"
 
 #. Default: "Hide empty block"
-#: ./ftw/news/contents/news_listing_block.py:35
+#: ./ftw/news/contents/news_listing_block.py:54
 msgid "label_hide_empty_block"
 msgstr "Leeren Block ausblenden"
 
@@ -175,7 +175,7 @@ msgid "label_mopage_trigger_url"
 msgstr "Mopage Trigger URL"
 
 #. Default: "Label for the \"more news\" link"
-#: ./ftw/news/contents/news_listing_block.py:24
+#: ./ftw/news/contents/news_listing_block.py:34
 msgid "label_more_news_link_label"
 msgstr "Label für den Link \"Weitere Einträge\""
 
@@ -241,7 +241,7 @@ msgid "news_listing_author_label"
 msgstr "von ${author}"
 
 #. Default: "Show title"
-#: ./ftw/news/contents/news_listing_block.py:18
+#: ./ftw/news/contents/news_listing_block.py:28
 msgid "news_listing_block_show_title_label"
 msgstr "Titel anzeigen"
 
@@ -279,6 +279,11 @@ msgstr "Nur Einträge aus einem bestimmten Pfad anzeigen"
 #: ./ftw/news/contents/common.py:27
 msgid "news_listing_config_filter_path_label"
 msgstr "Auf Pfad einschränken"
+
+#. Default: "Link to more items"
+#: ./ftw/news/contents/news_listing_block.py:43
+msgid "news_listing_config_items_link"
+msgstr "Link zu weiteren Einträgen"
 
 #. Default: "Only news younger than this value will be rendered. Enter 0 for no limitation."
 #: ./ftw/news/contents/common.py:86
@@ -333,7 +338,7 @@ msgstr "Einen Link zu weiteren Einträgen anzeigen (wird nur angezeigt, wenn es 
 #. Default: "Link to more news"
 #: ./ftw/news/contents/common.py:94
 msgid "news_listing_config_show_more_news_link_label"
-msgstr "Link zu weiteren Einträgen"
+msgstr "Link zu weiteren Einträgen anzeigen"
 
 #. Default: "Render a link to the RSS feed of the news."
 #: ./ftw/news/contents/common.py:106

--- a/ftw/news/locales/ftw.news.pot
+++ b/ftw/news/locales/ftw.news.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2019-08-29 12:03+0000\n"
+"POT-Creation-Date: 2019-09-10 12:38+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -117,7 +117,7 @@ msgid "archive"
 msgstr ""
 
 #. Default: "Hide the block if there are no news items to be shown."
-#: ./ftw/news/contents/news_listing_block.py:37
+#: ./ftw/news/contents/news_listing_block.py:56
 msgid "description_hide_empty_block"
 msgstr ""
 
@@ -132,7 +132,7 @@ msgid "description_mopage_trigger_url"
 msgstr ""
 
 #. Default: "This custom label will not be translated."
-#: ./ftw/news/contents/news_listing_block.py:26
+#: ./ftw/news/contents/news_listing_block.py:36
 msgid "description_more_news_link_label"
 msgstr ""
 
@@ -160,7 +160,7 @@ msgid "label_feed_desc"
 msgstr ""
 
 #. Default: "Hide empty block"
-#: ./ftw/news/contents/news_listing_block.py:35
+#: ./ftw/news/contents/news_listing_block.py:54
 msgid "label_hide_empty_block"
 msgstr ""
 
@@ -175,7 +175,7 @@ msgid "label_mopage_trigger_url"
 msgstr ""
 
 #. Default: "Label for the \"more news\" link"
-#: ./ftw/news/contents/news_listing_block.py:24
+#: ./ftw/news/contents/news_listing_block.py:34
 msgid "label_more_news_link_label"
 msgstr ""
 
@@ -241,7 +241,7 @@ msgid "news_listing_author_label"
 msgstr ""
 
 #. Default: "Show title"
-#: ./ftw/news/contents/news_listing_block.py:18
+#: ./ftw/news/contents/news_listing_block.py:28
 msgid "news_listing_block_show_title_label"
 msgstr ""
 
@@ -278,6 +278,11 @@ msgstr ""
 #. Default: "Limit to path"
 #: ./ftw/news/contents/common.py:27
 msgid "news_listing_config_filter_path_label"
+msgstr ""
+
+#. Default: "Link to more items"
+#: ./ftw/news/contents/news_listing_block.py:43
+msgid "news_listing_config_items_link"
 msgstr ""
 
 #. Default: "Only news younger than this value will be rendered. Enter 0 for no limitation."

--- a/ftw/news/testing.py
+++ b/ftw/news/testing.py
@@ -13,6 +13,7 @@ from plone.app.testing import applyProfile
 from plone.testing import z2
 from zope.configuration import xmlconfig
 import ftw.news.tests.builders
+import ftw.referencewidget.tests.widgets
 
 
 class FtwNewsLayer(PloneSandboxLayer):


### PR DESCRIPTION
<img width="797" alt="Bildschirmfoto 2019-09-10 um 15 02 44" src="https://user-images.githubusercontent.com/50165195/64616103-2051ac00-d3dc-11e9-9595-a73b6935b25f.png">

closes https://github.com/4teamwork/bgbern.ng/issues/471