### PR TITLE
Make news archive portlet importable (GS).

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.15.2 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Make news archive portlet importable (GS). [mathias.leimgruber]
 
 
 1.15.1 (2020-05-28)

--- a/ftw/news/portlets/news_archive_portlet.py
+++ b/ftw/news/portlets/news_archive_portlet.py
@@ -159,7 +159,7 @@ class INewsArchivePortlet(IPortletDataProvider):
 class Assignment(base.Assignment):
     implements(INewsArchivePortlet)
 
-    def __init__(self, portlet_title):
+    def __init__(self, portlet_title=''):
         self._portlet_title = portlet_title
 
     @property


### PR DESCRIPTION
If a portlet assignment gets created with a portlets.xml the assigment instance is initialized without an additional parameter.
Thus the API of the archive portlet was wrong and it was not. possible to import at all. 

The problem is solved by adding a default value to the required param. 