### PR TITLE
Respect lead image config of NewsListingBlock on new_listing view.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.10.3 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Respect lead image config of NewsListingBlock on new_listing view. [mathias.leimgruber]
 
 
 1.10.2 (2018-08-22)

--- a/ftw/news/browser/news_listing.py
+++ b/ftw/news/browser/news_listing.py
@@ -4,6 +4,7 @@ from DateTime import DateTime
 from DateTime import DateTime
 from ftw.news import _
 from ftw.news import utils
+from ftw.news.contents.common import INewsListingBaseSchema
 from ftw.news.interfaces import INewsListingView
 from ftw.simplelayout.contenttypes.contents.interfaces import IContentPage
 from plone import api
@@ -73,14 +74,19 @@ class NewsListing(BrowserView):
     def get_item_dict(self, brain):
         obj = brain.getObject()
 
+        news_listing_block = INewsListingBaseSchema(self.context, None)
+        image_tag = ''
+        if getattr(news_listing_block, 'show_lead_image', True):
+            image_tag = obj.restrictedTraverse('@@leadimage')(
+                'news_listing_image')
+
         item = {
             'title': brain.Title,
             'description': brain.Description,
             'url': brain.getURL(),
             'author': utils.get_creator(obj) if utils.can_view_about() else '',
             'news_date': self.format_date(brain),
-            'image_tag': obj.restrictedTraverse('@@leadimage')(
-                'news_listing_image'),
+            'image_tag': image_tag,
         }
         return item
 

--- a/ftw/news/tests/test_news_listing_block.py
+++ b/ftw/news/tests/test_news_listing_block.py
@@ -155,12 +155,20 @@ class TestNewsListingBlockContentType(FunctionalTestCase):
             'Textblock with image',
             browser.css(lead_image_css_selector).first.attrib['title']
         )
+        browser.login().visit(block, view='block_view')
+        self.assertEqual(
+            'Textblock with image',
+            browser.css(lead_image_css_selector).first.attrib['title']
+        )
+
 
         # Now edit the block so it will not show the lead image.
         browser.visit(block, view='edit')
         browser.fill({'Show lead image': False}).save()
 
         browser.visit(page)
+        self.assertEqual([], browser.css(lead_image_css_selector))
+        browser.login().visit(block, view='block_view')
         self.assertEqual([], browser.css(lead_image_css_selector))
 
     @browsing


### PR DESCRIPTION
Before this change a news listing showed the image again after clicking on "further entries" on a newslisting block not showing any images. This was confusing for some users.