### PR TITLE
Respect lead image config of NewsListingBlock on new_listing view.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.15.3 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Respect lead image config of NewsListingBlock on new_listing view. [mathias.leimgruber]
 
 
 1.15.2 (2020-07-30)

--- a/ftw/news/browser/news_listing.py
+++ b/ftw/news/browser/news_listing.py
@@ -3,6 +3,7 @@ from Acquisition import aq_parent
 from DateTime import DateTime
 from ftw.news import _
 from ftw.news import utils
+from ftw.news.contents.common import INewsListingBaseSchema
 from ftw.news.interfaces import INewsListingView
 from ftw.simplelayout.contenttypes.contents.interfaces import IContentPage
 from plone import api
@@ -76,7 +77,11 @@ class NewsListing(BrowserView):
     def get_item_dict(self, brain):
         obj = brain.getObject()
 
-        image_tag = obj.restrictedTraverse('@@leadimage')('news_listing_image', direction='thumbnail')
+        news_listing_block = INewsListingBaseSchema(self.context, None)
+        image_tag = ''
+        if getattr(news_listing_block, 'show_lead_image', True):
+            image_tag = obj.restrictedTraverse('@@leadimage')('news_listing_image', direction='thumbnail')
+
         item = {
             'title': brain.Title,
             'description': brain.Description,

--- a/ftw/news/tests/test_news_listing_block.py
+++ b/ftw/news/tests/test_news_listing_block.py
@@ -159,12 +159,19 @@ class TestNewsListingBlockContentType(FunctionalTestCase):
             'Textblock with image',
             browser.css(lead_image_css_selector).first.attrib['title']
         )
+        browser.login().visit(block, view='news_listing')
+        self.assertEqual(
+            'Textblock with image',
+            browser.css(lead_image_css_selector).first.attrib['title']
+        )
 
         # Now edit the block so it will not show the lead image.
         browser.visit(block, view='edit')
         browser.fill({'Show lead image': False}).save()
 
         browser.visit(page)
+        self.assertEqual([], browser.css(lead_image_css_selector))
+        browser.login().visit(block, view='news_listing')
         self.assertEqual([], browser.css(lead_image_css_selector))
 
     @browsing


### PR DESCRIPTION
This is a cherry-pick from f0b2da575bcd7ee6fbeed9f746db96de68792d7f


> Before this change a news listing showed the image again after clicking on "further entries" on a newslisting block not showing any images. This was confusing for some users.