### PR TITLE
Fix mopage text too small

### DIFF
--- a/ftw/news/browser/mopage.py
+++ b/ftw/news/browser/mopage.py
@@ -110,7 +110,7 @@ class NewsMopageRenderer(SimplelayoutRenderer):
         # and we need to crop more to compensate.
         for attempt in range(100):
             fraction = int(len(text) * .1)
-            text = crop(10000 if fraction < 0 else 10000 - fraction, text)
+            text = crop(10000 if fraction >= 9000 else 10000 - fraction, text)
             html = portal_transforms.convertToData(
                 'text/html',
                 text,


### PR DESCRIPTION
I accidentally checked if the fractions length was smaller than 0 instead of 10000 - fraction. This happened during refactoring... Now we have a better check that also ensures that the text won't be smaller than 1k chars (eg. a text that is 99k chars long would have resulted in a 9char long output)